### PR TITLE
ci: speed up build and release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,8 @@ jobs:
     runs-on: lynx-ubuntu-24.04-xlarge
     steps:
       - uses: actions/checkout@v4
-      - name: Fetch base branch for comparison
-        run: |
-          git fetch --depth=1 origin ${{ github.base_ref }}
-          git branch -f ${{ github.base_ref }} origin/${{ github.base_ref }}
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
         run: |
           pnpm dprint check
       - name: Build
-        run: pnpm turbo build
+        run: pnpm turbo build --affected

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
         run: |
           pnpm dprint check
       - name: Build
-        run: pnpm turbo build --affected
+        run: pnpm turbo run build --affected

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,6 @@ jobs:
         run: |
           pnpm dprint check
       - name: Build
+        env:
+          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
         run: pnpm turbo run build --affected

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
     runs-on: lynx-ubuntu-24.04-xlarge
     steps:
       - uses: actions/checkout@v4
+      - name: Fetch base branch for comparison
+        run: |
+          git fetch --depth=1 origin ${{ github.base_ref }}
+          git branch -f ${{ github.base_ref }} origin/${{ github.base_ref }}
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,14 +40,11 @@ jobs:
           corepack enable
           pnpm install
 
-      - name: Build
-        run: pnpm turbo build
-
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm changeset publish
+          publish: pnpm turbo build && pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
1. Add `--affected` to `turbo build`. See: https://turbo.build/repo/docs/crafting-your-repository/constructing-ci#using---affected-in-github-actions
2. Only run `turbo build` when publishing.