### PR TITLE
feat: Change the usage of lynx.__globalProps to SystemInfo in Gallery

### DIFF
--- a/.changeset/sharp-planets-burn.md
+++ b/.changeset/sharp-planets-burn.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/gallery": patch
+---
+
+feat: Change the usage of lynx.__globalProps to SystemInfo in Gallery

--- a/examples/Gallery/src/AddNiceScrollbar/NiceScrollbar.tsx
+++ b/examples/Gallery/src/AddNiceScrollbar/NiceScrollbar.tsx
@@ -10,7 +10,7 @@ export const NiceScrollbar = forwardRef((_, ref) => {
   const [scrollbarTop, setScrollbarTop] = useState(0);
 
   const adjustScrollbar = (scrollTop: number, scrollHeight: number) => {
-    const listHeight = lynx.__globalProps.screenHeight - 48;
+    const listHeight = SystemInfo.pixelHeight / SystemInfo.pixelRatio - 48;
     const scrollbarHeight = listHeight * (listHeight / scrollHeight);
     const scrollbarTop = listHeight * (scrollTop / scrollHeight);
     setScrollbarHeight(scrollbarHeight);

--- a/examples/Gallery/src/GalleryComplete/NiceScrollbarMTS.tsx
+++ b/examples/Gallery/src/GalleryComplete/NiceScrollbarMTS.tsx
@@ -4,7 +4,7 @@ import { MainThread } from "@lynx-js/types";
 
 export const adjustScrollbarMTS = (scrollTop: number, scrollHeight: number, ref: RefObject<MainThread.Element>) => {
   "main thread";
-  const listHeight = lynx.__globalProps.screenHeight - 48;
+  const listHeight = SystemInfo.pixelHeight / SystemInfo.pixelRatio - 48;
   const scrollbarHeight = listHeight * (listHeight / scrollHeight);
   const scrollbarTop = listHeight * (scrollTop / scrollHeight);
   ref.current?.setStyleProperties({

--- a/examples/Gallery/src/ScrollbarCompare/NiceScrollbar.tsx
+++ b/examples/Gallery/src/ScrollbarCompare/NiceScrollbar.tsx
@@ -10,7 +10,7 @@ export const NiceScrollbar = forwardRef((_, ref) => {
   const [scrollbarTop, setScrollbarTop] = useState(0);
 
   const adjustScrollbar = (scrollTop: number, scrollHeight: number) => {
-    const listHeight = lynx.__globalProps.screenHeight;
+    const listHeight = SystemInfo.pixelHeight / SystemInfo.pixelRatio;
     const scrollbarHeight = listHeight * (listHeight / scrollHeight);
     const scrollbarTop = listHeight * (scrollTop / scrollHeight);
     setScrollbarHeight(scrollbarHeight);

--- a/examples/Gallery/src/ScrollbarCompare/NiceScrollbarMTS.tsx
+++ b/examples/Gallery/src/ScrollbarCompare/NiceScrollbarMTS.tsx
@@ -4,7 +4,7 @@ import { MainThread } from "@lynx-js/types";
 
 export const adjustScrollbarMTS = (scrollTop: number, scrollHeight: number, ref: RefObject<MainThread.Element>) => {
   "main thread";
-  const listHeight = lynx.__globalProps.screenHeight;
+  const listHeight = SystemInfo.pixelHeight / SystemInfo.pixelRatio;
   const scrollbarHeight = listHeight * (listHeight / scrollHeight);
   const scrollbarTop = listHeight * (scrollTop / scrollHeight);
   ref.current?.setStyleProperties({

--- a/examples/Gallery/src/utils.tsx
+++ b/examples/Gallery/src/utils.tsx
@@ -3,7 +3,7 @@ export const calculateEstimatedSize = (pictureWidth: number, pictureHeight: numb
   const galleryPadding = 20;
   const galleryMainAxisGap = 10;
   const gallerySpanCount = 2;
-  const galleryWidth = lynx.__globalProps.screenWidth;
+  const galleryWidth = SystemInfo.pixelWidth / SystemInfo.pixelRatio;
   // Calculate the width of each ImageCard and return the relative height of the it.
   const itemWidth = (galleryWidth - galleryPadding * 2 - galleryMainAxisGap) / gallerySpanCount;
   return itemWidth / pictureWidth * pictureHeight;


### PR DESCRIPTION
The lynx.__globalProps may not exist in an empty project in oss environment. So we need to change to SystemInfo to make sure it still works.