### PR TITLE
fix: use SystemInfo instead of globalProps

### DIFF
--- a/.changeset/huge-suns-show.md
+++ b/.changeset/huge-suns-show.md
@@ -1,0 +1,5 @@
+---
+'@lynx-example/swiper': patch
+---
+
+Use `SystemInfo` instead of `globalProps`

--- a/examples/swiper/src/Components/SafeArea/index.tsx
+++ b/examples/swiper/src/Components/SafeArea/index.tsx
@@ -3,7 +3,7 @@ import type { CSSProperties } from "@lynx-js/types";
 import "./styles.scss";
 
 export default function SafeArea({ children, style }: { children: ReactNode; style?: CSSProperties }) {
-  const isIOS = lynx.__globalProps.platform === "ios";
+  const isIOS = SystemInfo.platform === "iOS";
 
   return (
     <view class={`safe-area ${isIOS ? "ios" : "android"}`} style={style}>

--- a/examples/swiper/src/EasingDefault/Swiper.tsx
+++ b/examples/swiper/src/EasingDefault/Swiper.tsx
@@ -7,7 +7,7 @@ import { useUpdateSwiperStyle } from "./useUpdateSwiperStyle";
 
 export function Swiper({
   data,
-  itemWidth = lynx.__globalProps.screenWidth,
+  itemWidth = SystemInfo.pixelWidth / SystemInfo.pixelRatio,
 }: {
   data: string[];
   itemWidth?: number;

--- a/examples/swiper/src/MTSIndicator/Swiper.tsx
+++ b/examples/swiper/src/MTSIndicator/Swiper.tsx
@@ -7,7 +7,7 @@ import { useUpdateSwiperStyle } from "./useUpdateSwiperStyle";
 
 export function Swiper({
   data,
-  itemWidth = lynx.__globalProps.screenWidth,
+  itemWidth = SystemInfo.pixelWidth / SystemInfo.pixelRatio,
 }: {
   data: string[];
   itemWidth?: number;

--- a/examples/swiper/src/MTSIndicatorCurrent/Swiper.tsx
+++ b/examples/swiper/src/MTSIndicatorCurrent/Swiper.tsx
@@ -7,7 +7,7 @@ import { useUpdateSwiperStyle } from "./useUpdateSwiperStyle";
 
 export function Swiper({
   data,
-  itemWidth = lynx.__globalProps.screenWidth,
+  itemWidth = SystemInfo.pixelWidth / SystemInfo.pixelRatio,
 }: {
   data: string[];
   itemWidth?: number;

--- a/examples/swiper/src/MTSIndicatorEmpty/Swiper.tsx
+++ b/examples/swiper/src/MTSIndicatorEmpty/Swiper.tsx
@@ -7,7 +7,7 @@ import { useUpdateSwiperStyle } from "./useUpdateSwiperStyle";
 
 export function Swiper({
   data,
-  itemWidth = lynx.__globalProps.screenWidth,
+  itemWidth = SystemInfo.pixelWidth / SystemInfo.pixelRatio,
 }: {
   data: string[];
   itemWidth?: number;

--- a/examples/swiper/src/MTSIndicatorWrong/Swiper.tsx
+++ b/examples/swiper/src/MTSIndicatorWrong/Swiper.tsx
@@ -7,7 +7,7 @@ import { useUpdateSwiperStyle } from "./useUpdateSwiperStyle";
 
 export function Swiper({
   data,
-  itemWidth = lynx.__globalProps.screenWidth,
+  itemWidth = SystemInfo.pixelWidth / SystemInfo.pixelRatio,
   itemHeight = 300,
 }: {
   data: string[];

--- a/examples/swiper/src/Swiper/Swiper.tsx
+++ b/examples/swiper/src/Swiper/Swiper.tsx
@@ -7,7 +7,7 @@ import { useUpdateSwiperStyle } from "./useUpdateSwiperStyle";
 
 export function Swiper({
   data,
-  itemWidth = lynx.__globalProps.screenWidth,
+  itemWidth = SystemInfo.pixelWidth / SystemInfo.pixelRatio,
   duration,
   "main-thread:easing": MTEasing,
 }: {

--- a/examples/swiper/src/SwiperEmpty/Swiper.tsx
+++ b/examples/swiper/src/SwiperEmpty/Swiper.tsx
@@ -3,7 +3,7 @@ import { SwiperItem } from "./SwiperItem";
 
 export function Swiper({
   data,
-  itemWidth = lynx.__globalProps.screenWidth,
+  itemWidth = SystemInfo.pixelWidth / SystemInfo.pixelRatio,
 }: {
   data: string[];
   itemWidth?: number;

--- a/examples/swiper/src/SwiperHooks/Swiper.tsx
+++ b/examples/swiper/src/SwiperHooks/Swiper.tsx
@@ -5,7 +5,7 @@ import { useUpdateSwiperStyle } from "./useUpdateSwiperStyle";
 
 export function Swiper({
   data,
-  itemWidth = lynx.__globalProps.screenWidth,
+  itemWidth = SystemInfo.pixelWidth / SystemInfo.pixelRatio,
 }: {
   data: string[];
   itemWidth?: number;

--- a/examples/swiper/src/SwiperMTS/Swiper.tsx
+++ b/examples/swiper/src/SwiperMTS/Swiper.tsx
@@ -5,7 +5,7 @@ import { useUpdateSwiperStyle } from "./useUpdateSwiperStyle";
 
 export function Swiper({
   data,
-  itemWidth = lynx.__globalProps.screenWidth,
+  itemWidth = SystemInfo.pixelWidth / SystemInfo.pixelRatio,
 }: {
   data: string[];
   itemWidth?: number;

--- a/examples/swiper/src/UpdateOffset/Swiper.tsx
+++ b/examples/swiper/src/UpdateOffset/Swiper.tsx
@@ -5,7 +5,7 @@ import { SwiperItem } from "./SwiperItem";
 
 export function Swiper({
   data,
-  itemWidth = lynx.__globalProps.screenWidth,
+  itemWidth = SystemInfo.pixelWidth / SystemInfo.pixelRatio,
 }: {
   data: string[];
   itemWidth?: number;


### PR DESCRIPTION
The lynx.__globalProps may not exist in an empty project in oss environment. So we need to change to SystemInfo to make sure it still works.