### PR TITLE
className typo fix

### DIFF
--- a/.changeset/rotten-insects-ring.md
+++ b/.changeset/rotten-insects-ring.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/css": patch
+---
+
+Change `class` to `className`.

--- a/examples/css/src/class_guide/index.tsx
+++ b/examples/css/src/class_guide/index.tsx
@@ -13,7 +13,7 @@ function App() {
         width: "150px",
         height: "150px",
       }}
-      class="bg-gradient"
+      className="bg-gradient"
     >
     </view>
   );


### PR DESCRIPTION
In the code example, using class instead of className in ReactLynx appears to be a typo. It is recommended to use only **className** in **ReactLynx**. For more details, refer to the official documentation:  https://lynxjs.org/guide/ui/styling.html