### PR TITLE
fix(with-solidjs): remove extraneous jsxImportSource

### DIFF
--- a/examples/with-solidjs/tsconfig.json
+++ b/examples/with-solidjs/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "jsx": "preserve",
-    "jsxImportSource": "@lynx-js/react",
     "jsxImportSource": "@lynx-js/solid",
 
     "module": "node16",


### PR DESCRIPTION
It looks like this was added accidentally in f1d4d6ee49069f44cbd30cab2e1e49946e21662d.
