### PR TITLE
fix: use `declare module` instead of `declare let`

### DIFF
--- a/.changeset/red-hands-leave.md
+++ b/.changeset/red-hands-leave.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/local-storage": patch
+---
+
+Extending `NativeModules` from `@lynx-js/types`

--- a/examples/local-storage/src/typing.d.ts
+++ b/examples/local-storage/src/typing.d.ts
@@ -2,10 +2,14 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-declare let NativeModules: {
-  NativeLocalStorageModule: {
-    setStorageItem(key: string, value: string): void;
-    getStorageItem(key: string): string | null;
-    clearStorage(): void;
-  };
-};
+declare module "@lynx-js/types" {
+  interface NativeModules {
+    NativeLocalStorageModule: {
+      setStorageItem(key: string, value: string): void;
+      getStorageItem(key: string): string | null;
+      clearStorage(): void;
+    };
+  }
+}
+
+export {};


### PR DESCRIPTION
A better example for using `NativeModules`. See https://github.com/lynx-family/lynx-website/issues/183