### PR TITLE
fix: resolve breaking change introduced in `@tanstack/router@1.127.9` and update to latest version

### DIFF
--- a/.changeset/gold-shoes-hunt.md
+++ b/.changeset/gold-shoes-hunt.md
@@ -3,4 +3,5 @@
 ---
 
 Resolve breaking change introduced in `@tanstack/router@1.127.9`. 
+
 Fix white screen issue on ReactLynx by explicitly setting `isServer: false` in router configuration to override incorrect server environment detection.

--- a/.changeset/gold-shoes-hunt.md
+++ b/.changeset/gold-shoes-hunt.md
@@ -1,0 +1,6 @@
+---
+"@lynx-example/tanstack-router": patch
+---
+
+Resolve breaking change introduced in `@tanstack/router@1.127.9`. 
+Fix white screen issue on ReactLynx by explicitly setting `isServer: false` in router configuration to override incorrect server environment detection.

--- a/.changeset/gold-shoes-hunt.md
+++ b/.changeset/gold-shoes-hunt.md
@@ -2,6 +2,6 @@
 "@lynx-example/tanstack-router": patch
 ---
 
-Resolve breaking change introduced in `@tanstack/router@1.127.9`. 
+Resolve breaking change introduced in `@tanstack/router@1.127.9`.
 
 Fix white screen issue on ReactLynx by explicitly setting `isServer: false` in router configuration to override incorrect server environment detection.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -59,8 +59,6 @@
     "pnpmDedupe"
   ],
   "ignoreDeps": [
-    "node",
-    "@tanstack/react-router",
-    "@tanstack/router-plugin"
+    "node"
   ]
 }

--- a/examples/tanstack-router/package.json
+++ b/examples/tanstack-router/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@lynx-js/react": "catalog:",
-    "@tanstack/react-router": "1.121.34",
+    "@tanstack/react-router": "1.131.36",
     "url-search-params-polyfill": "^8.2.5"
   },
   "devDependencies": {
@@ -29,7 +29,7 @@
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
     "@lynx-js/types": "^3.4.11",
-    "@tanstack/router-plugin": "1.121.34",
+    "@tanstack/router-plugin": "1.131.36",
     "@types/react": "^18.3.23"
   }
 }

--- a/examples/tanstack-router/src/App.tsx
+++ b/examples/tanstack-router/src/App.tsx
@@ -6,7 +6,7 @@ const memoryHistory = createMemoryHistory({
   initialEntries: ["/"],
 });
 
-const router = createRouter({ routeTree, history: memoryHistory });
+const router = createRouter({ routeTree, history: memoryHistory, isServer: false });
 
 export function App() {
   return <RouterProvider router={router} />;

--- a/examples/tanstack-router/src/routes/__root.tsx
+++ b/examples/tanstack-router/src/routes/__root.tsx
@@ -20,7 +20,7 @@ function RootComponent() {
       <Outlet />
 
       <image
-        src="https://tanstack.com/assets/splash-dark-8nwlc0Nt.png"
+        src="https://tanstack.com/images/logos/splash-light.png"
         style={{
           height: "150px",
           width: "150px",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -855,8 +855,8 @@ importers:
         specifier: 'catalog:'
         version: 0.112.6(@lynx-js/types@3.4.11)(@types/react@18.3.23)
       '@tanstack/react-router':
-        specifier: 1.121.34
-        version: 1.121.34(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        specifier: 1.131.36
+        version: 1.131.36(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       url-search-params-polyfill:
         specifier: ^8.2.5
         version: 8.2.5
@@ -874,8 +874,8 @@ importers:
         specifier: ^3.4.11
         version: 3.4.11
       '@tanstack/router-plugin':
-        specifier: 1.121.34
-        version: 1.121.34(@rsbuild/core@1.5.2)(@tanstack/react-router@1.121.34(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(webpack@5.101.3)
+        specifier: 1.131.36
+        version: 1.131.36(@rsbuild/core@1.5.2)(@tanstack/react-router@1.131.36(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(webpack@5.101.3)
       '@types/react':
         specifier: ^18.3.23
         version: 18.3.23
@@ -2156,10 +2156,6 @@ packages:
   '@swc/helpers@0.5.17':
     resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
 
-  '@tanstack/history@1.121.34':
-    resolution: {integrity: sha512-YL8dGi5ZU+xvtav2boRlw4zrRghkY6hvdcmHhA0RGSJ/CBgzv+cbADW9eYJLx74XMZvIQ1pp6VMbrpXnnM5gHA==}
-    engines: {node: '>=12'}
-
   '@tanstack/history@1.131.2':
     resolution: {integrity: sha512-cs1WKawpXIe+vSTeiZUuSBy8JFjEuDgdMKZFRLKwQysKo8y2q6Q1HvS74Yw+m5IhOW1nTZooa6rlgdfXcgFAaw==}
     engines: {node: '>=12'}
@@ -2172,8 +2168,8 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@tanstack/react-router@1.121.34':
-    resolution: {integrity: sha512-nQYUXh459/YX9tDOGUqBb8yCiUw4JjcCf1o9wtb9fMxy3hnP0iQNU2TeV1A1N4KCGKXV3ZzkhpBb6sJe3kd43Q==}
+  '@tanstack/react-router@1.131.36':
+    resolution: {integrity: sha512-9tglm3Rf9qkANBIyYLbGlOjNj7GDBr0jOEOaADfwiGV3Ua3P562MGn7nHUOrfRfA6u2MCg0EKJ+LH7AeWxAqkg==}
     engines: {node: '>=12'}
     peerDependencies:
       react: '>=18.0.0 || >=19.0.0'
@@ -2185,24 +2181,20 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/router-core@1.121.34':
-    resolution: {integrity: sha512-CRH9dC8uLfFOKUGTbtOcMPv+weNVt2xs+me34KLX0Yja2yHG99oAUCBwamXsVQPpfjLFPYeJuKyo98+Mg+Ppeg==}
+  '@tanstack/router-core@1.131.36':
+    resolution: {integrity: sha512-faGrKwrJBjJDxbcyeaOXgQcyccmzIGkwk+tnFeJuMTnH5OMfArykYnTZ9BxIrlOY2Mori9DXmYKMlig6mVqmGA==}
     engines: {node: '>=12'}
 
-  '@tanstack/router-core@1.131.27':
-    resolution: {integrity: sha512-NEBNxZ/LIBIh6kvQntr6bKq57tDe55zecyTtjAmzPkYFsMy1LXEpRm5H3BPiteBMRApAjuaq+bS1qA664hLH6Q==}
+  '@tanstack/router-generator@1.131.36':
+    resolution: {integrity: sha512-Rl1Q2DFcAFXaYSvHQwO+HKmp5zSBz8D3qZl+fJ0a0w4/2I+Km1xwjzDwBUkFVNJtTUor40uU76SYJzV0/9s1tw==}
     engines: {node: '>=12'}
 
-  '@tanstack/router-generator@1.131.27':
-    resolution: {integrity: sha512-PXBIVl45q2bBq9g0DDXLBGeKjO9eExcZd2JotLjLdIJ0I/wdxPQOBJHLPZfnmbf3vispToedRvG3b1YDWjL48g==}
-    engines: {node: '>=12'}
-
-  '@tanstack/router-plugin@1.121.34':
-    resolution: {integrity: sha512-ZmX/tkdd/ZKLdr17ewKJTTBGkXQDeOfQKSCuuEW5IjiNfWjT5gx8rQDvcYUSRcZdpUZ0LvDBxJUI74oHQ3sAiw==}
+  '@tanstack/router-plugin@1.131.36':
+    resolution: {integrity: sha512-EU/NopEkQw3AyjZvB33r4uIfUtbU64rbdJDCgGfumv1wpi/B4lJTO9W6iiUsoIsi1mtlNQKbFKNIbx+VyGh19Q==}
     engines: {node: '>=12'}
     peerDependencies:
       '@rsbuild/core': '>=1.0.2'
-      '@tanstack/react-router': ^1.121.34
+      '@tanstack/react-router': ^1.131.36
       vite: '>=5.0.0 || >=6.0.0'
       vite-plugin-solid: ^2.11.2
       webpack: '>=5.92.0'
@@ -3654,6 +3646,10 @@ packages:
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
+  isbot@5.1.30:
+    resolution: {integrity: sha512-3wVJEonAns1OETX83uWsk5IAne2S5zfDcntD2hbtU23LelSqNXzXs9zKjMPOLMzroCgIjCfjYAEHrd2D6FOkiA==}
+    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -6431,8 +6427,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tanstack/history@1.121.34': {}
-
   '@tanstack/history@1.131.2': {}
 
   '@tanstack/query-core@5.85.5': {}
@@ -6442,12 +6436,12 @@ snapshots:
       '@tanstack/query-core': 5.85.5
       react: 19.1.1
 
-  '@tanstack/react-router@1.121.34(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@tanstack/react-router@1.131.36(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
-      '@tanstack/history': 1.121.34
+      '@tanstack/history': 1.131.2
       '@tanstack/react-store': 0.7.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@tanstack/router-core': 1.121.34
-      jsesc: 3.1.0
+      '@tanstack/router-core': 1.131.36
+      isbot: 5.1.30
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       tiny-invariant: 1.3.3
@@ -6460,13 +6454,7 @@ snapshots:
       react-dom: 19.1.1(react@19.1.1)
       use-sync-external-store: 1.5.0(react@19.1.1)
 
-  '@tanstack/router-core@1.121.34':
-    dependencies:
-      '@tanstack/history': 1.121.34
-      '@tanstack/store': 0.7.2
-      tiny-invariant: 1.3.3
-
-  '@tanstack/router-core@1.131.27':
+  '@tanstack/router-core@1.131.36':
     dependencies:
       '@tanstack/history': 1.131.2
       '@tanstack/store': 0.7.2
@@ -6476,9 +6464,9 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/router-generator@1.131.27':
+  '@tanstack/router-generator@1.131.36':
     dependencies:
-      '@tanstack/router-core': 1.131.27
+      '@tanstack/router-core': 1.131.36
       '@tanstack/router-utils': 1.131.2
       '@tanstack/virtual-file-routes': 1.131.2
       prettier: 3.6.2
@@ -6489,7 +6477,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.121.34(@rsbuild/core@1.5.2)(@tanstack/react-router@1.121.34(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(webpack@5.101.3)':
+  '@tanstack/router-plugin@1.131.36(@rsbuild/core@1.5.2)(@tanstack/react-router@1.131.36(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(webpack@5.101.3)':
     dependencies:
       '@babel/core': 7.28.3
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.3)
@@ -6497,8 +6485,8 @@ snapshots:
       '@babel/template': 7.27.2
       '@babel/traverse': 7.28.3
       '@babel/types': 7.28.2
-      '@tanstack/router-core': 1.131.27
-      '@tanstack/router-generator': 1.131.27
+      '@tanstack/router-core': 1.131.36
+      '@tanstack/router-generator': 1.131.36
       '@tanstack/router-utils': 1.131.2
       '@tanstack/virtual-file-routes': 1.131.2
       babel-dead-code-elimination: 1.0.10
@@ -6507,7 +6495,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@rsbuild/core': 1.5.2
-      '@tanstack/react-router': 1.121.34(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@tanstack/react-router': 1.131.36(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       webpack: 5.101.3
     transitivePeerDependencies:
       - supports-color
@@ -8079,6 +8067,8 @@ snapshots:
   isarray@1.0.0: {}
 
   isarray@2.0.5: {}
+
+  isbot@5.1.30: {}
 
   isexe@2.0.0: {}
 


### PR DESCRIPTION
This PR addresses a white screen issue when using `@tanstack/router@1.127.9` and above with ReactLynx. The problem was introduced in [#4621](https://github.com/TanStack/router/pull/4621/files#diff-4cfd6abe2272d72c1dd073ec37936ad823bcd1f9418b466a9dea8b50214448f8R57) where `useRouter().isServer` returns `true` on Lynx due to the default detection logic `typeof document !== undefined` incorrectly identifying it as a server environment.

The fix explicitly passes `isServer: false` when creating the router to override the automatic detection and ensure proper rendering on ReactLynx.