### PR TITLE
chore: fix publishing

### DIFF
--- a/examples/with-solidjs/packages/solid/package.json
+++ b/examples/with-solidjs/packages/solid/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@lynx-js/solid",
+  "version": "0.0.0",
   "module": "./src/index.ts",
   "types": "./src/index.ts",
   "private": true,


### PR DESCRIPTION
Fix the "Cannot resolve workspace protocol of dependency \"@lynx-js/solid\" because this dependency is not installed. Try running \"pnpm install\"." error during publishing.