### PR TITLE
fix: list scrollbar lag

### DIFF
--- a/.changeset/blue-cars-drive.md
+++ b/.changeset/blue-cars-drive.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/gallery": patch
+---
+
+Add scroll-event-throttle to deal with lag

--- a/examples/Gallery/src/AddNiceScrollbar/Gallery.tsx
+++ b/examples/Gallery/src/AddNiceScrollbar/Gallery.tsx
@@ -43,6 +43,7 @@ export const Gallery = (props: { pictureData: Picture[] }) => {
         scroll-orientation="vertical"
         custom-list-name="list-container"
         bindscroll={onScroll}
+        scroll-event-throttle={0}
       >
         {pictureData.map((picture: Picture, index: number) => (
           <list-item

--- a/examples/Gallery/src/GalleryComplete/Gallery.tsx
+++ b/examples/Gallery/src/GalleryComplete/Gallery.tsx
@@ -40,6 +40,7 @@ export const Gallery = (
         scroll-orientation="vertical"
         custom-list-name="list-container"
         main-thread:bindscroll={onScrollMTS}
+        scroll-event-throttle={0}
       >
         {pictureData.map((picture: Picture, index: number) => (
           <list-item

--- a/examples/Gallery/src/ScrollbarCompare/Gallery.tsx
+++ b/examples/Gallery/src/ScrollbarCompare/Gallery.tsx
@@ -55,6 +55,7 @@ export const Gallery = (props: { pictureData: Picture[] }) => {
         custom-list-name="list-container"
         bindscroll={onScroll}
         main-thread:bindscroll={onScrollMTS}
+        scroll-event-throttle={0}
       >
         {pictureData.map((picture: Picture, index: number) => (
           <list-item


### PR DESCRIPTION
`scroll-event-throttle` has defaulted to `200` since Lynx 3.4, which breaks our customized scrollbar in our tutorial. We now need to set it to `0` manually for the tutorial 