### PR TITLE
Use fixed @lynx-js/types version.

### DIFF
--- a/.changeset/hot-wasps-sort.md
+++ b/.changeset/hot-wasps-sort.md
@@ -1,0 +1,41 @@
+---
+"@lynx-example/css-api": patch
+"@lynx-example/bankcards": patch
+"@lynx-example/gallery": patch
+"@lynx-example/accessibility": patch
+"@lynx-example/action-sheet": patch
+"@lynx-example/animation": patch
+"@lynx-example/composing-elements": patch
+"@lynx-example/css": patch
+"@lynx-example/element-manipulation": patch
+"@lynx-example/event": patch
+"@lynx-example/fetch": patch
+"@lynx-example/hello-world": patch
+"@lynx-example/i18n": patch
+"@lynx-example/ifr": patch
+"@lynx-example/image": patch
+"@lynx-example/input": patch
+"@lynx-example/layout": patch
+"@lynx-example/lazy-bundle": patch
+"@lynx-example/list": patch
+"@lynx-example/local-storage": patch
+"@lynx-example/lynx-api": patch
+"@lynx-example/main-thread": patch
+"@lynx-example/native-element": patch
+"@lynx-example/networking": patch
+"@lynx-example/page": patch
+"@lynx-example/performance-api": patch
+"@lynx-example/react-lifecycle": patch
+"@lynx-example/scroll-view": patch
+"@lynx-example/swiper": patch
+"@lynx-example/tailwindcss": patch
+"@lynx-example/tanstack-router": patch
+"@lynx-example/text": patch
+"@lynx-example/textarea": patch
+"@lynx-example/todolist": patch
+"@lynx-example/view": patch
+"@lynx-example/with-solidjs": patch
+"@lynx-example/zustand": patch
+---
+
+unify @lynx-js/types version.

--- a/api/css/package.json
+++ b/api/css/package.json
@@ -28,7 +28,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@rsbuild/plugin-sass": "1.4.0",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"

--- a/examples/BankCards/package.json
+++ b/examples/BankCards/package.json
@@ -27,7 +27,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@rsbuild/plugin-sass": "1.4.0",
     "@types/react": "^18.3.25"
   }

--- a/examples/Gallery/package.json
+++ b/examples/Gallery/package.json
@@ -28,7 +28,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@rsbuild/plugin-sass": "1.4.0",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"

--- a/examples/accessibility/package.json
+++ b/examples/accessibility/package.json
@@ -26,7 +26,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"
   },

--- a/examples/action-sheet/package.json
+++ b/examples/action-sheet/package.json
@@ -26,7 +26,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"
   },

--- a/examples/animation/package.json
+++ b/examples/animation/package.json
@@ -28,7 +28,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@rsbuild/plugin-sass": "1.4.0",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"

--- a/examples/composing-elements/package.json
+++ b/examples/composing-elements/package.json
@@ -26,7 +26,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"
   },

--- a/examples/css/package.json
+++ b/examples/css/package.json
@@ -28,7 +28,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@rsbuild/plugin-sass": "1.4.0",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"

--- a/examples/element-manipulation/package.json
+++ b/examples/element-manipulation/package.json
@@ -27,7 +27,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"
   },

--- a/examples/event/package.json
+++ b/examples/event/package.json
@@ -27,7 +27,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@rsbuild/plugin-sass": "1.4.0",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"

--- a/examples/fetch/package.json
+++ b/examples/fetch/package.json
@@ -27,7 +27,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@rsbuild/plugin-sass": "1.4.0",
     "@types/react": "^18.3.25"
   },

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -25,7 +25,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"
   },

--- a/examples/i18n/package.json
+++ b/examples/i18n/package.json
@@ -21,7 +21,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"
   },

--- a/examples/ifr/package.json
+++ b/examples/ifr/package.json
@@ -27,7 +27,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"
   },

--- a/examples/image/package.json
+++ b/examples/image/package.json
@@ -26,7 +26,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"
   },

--- a/examples/input/package.json
+++ b/examples/input/package.json
@@ -27,7 +27,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@rsbuild/plugin-sass": "1.4.0",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"

--- a/examples/layout/package.json
+++ b/examples/layout/package.json
@@ -28,7 +28,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@rsbuild/plugin-sass": "1.4.0",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"

--- a/examples/lazy-bundle/package.json
+++ b/examples/lazy-bundle/package.json
@@ -25,7 +25,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"
   },

--- a/examples/list/package.json
+++ b/examples/list/package.json
@@ -27,7 +27,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@rsbuild/plugin-sass": "1.4.0",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"

--- a/examples/local-storage/package.json
+++ b/examples/local-storage/package.json
@@ -26,7 +26,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"
   },

--- a/examples/lynx-api/package.json
+++ b/examples/lynx-api/package.json
@@ -27,7 +27,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"
   },

--- a/examples/main-thread/package.json
+++ b/examples/main-thread/package.json
@@ -27,7 +27,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"
   },

--- a/examples/native-element/package.json
+++ b/examples/native-element/package.json
@@ -26,7 +26,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"
   },

--- a/examples/networking/package.json
+++ b/examples/networking/package.json
@@ -28,7 +28,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@rsbuild/plugin-sass": "1.4.0",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"

--- a/examples/page/package.json
+++ b/examples/page/package.json
@@ -26,7 +26,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@rsbuild/plugin-sass": "1.4.0",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"

--- a/examples/performance-api/package.json
+++ b/examples/performance-api/package.json
@@ -27,7 +27,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@rsbuild/plugin-sass": "1.4.0",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"

--- a/examples/react-lifecycle/package.json
+++ b/examples/react-lifecycle/package.json
@@ -27,7 +27,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"
   },

--- a/examples/scroll-view/package.json
+++ b/examples/scroll-view/package.json
@@ -26,7 +26,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@rsbuild/plugin-sass": "1.4.0",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"

--- a/examples/swiper/package.json
+++ b/examples/swiper/package.json
@@ -27,7 +27,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@rsbuild/plugin-sass": "1.4.0",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"

--- a/examples/tailwindcss/package.json
+++ b/examples/tailwindcss/package.json
@@ -20,7 +20,7 @@
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
     "@lynx-js/tailwind-preset": "0.4.0",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@types/react": "^18.3.25",
     "tailwindcss": "^3.4.18",
     "typescript": "~5.9.3"

--- a/examples/tanstack-router/package.json
+++ b/examples/tanstack-router/package.json
@@ -29,7 +29,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@tanstack/router-plugin": "1.132.31",
     "@types/react": "^18.3.25"
   }

--- a/examples/text/package.json
+++ b/examples/text/package.json
@@ -28,7 +28,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@rsbuild/plugin-sass": "1.4.0",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"

--- a/examples/textarea/package.json
+++ b/examples/textarea/package.json
@@ -27,7 +27,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@rsbuild/plugin-sass": "1.4.0",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -27,7 +27,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@rsbuild/plugin-sass": "1.4.0",
     "@types/react": "^18.3.25"
   }

--- a/examples/view/package.json
+++ b/examples/view/package.json
@@ -26,7 +26,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"
   },

--- a/examples/web-platform/packages/lynx-project/package.json
+++ b/examples/web-platform/packages/lynx-project/package.json
@@ -16,7 +16,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3"
   },

--- a/examples/with-solidjs/package.json
+++ b/examples/with-solidjs/package.json
@@ -24,7 +24,7 @@
     "@babel/preset-typescript": "^7.27.1",
     "@lynx-js/solid": "workspace:*",
     "@lynx-js/template-webpack-plugin": "0.9.0",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@rspack/cli": "^1.5.8",
     "@rspack/core": "^1.5.8",
     "babel-loader": "^10.0.0",

--- a/examples/with-solidjs/packages/solid/package.json
+++ b/examples/with-solidjs/packages/solid/package.json
@@ -11,7 +11,7 @@
     "solid-js": "*"
   },
   "devDependencies": {
-    "@lynx-js/types": "^3.4.11"
+    "@lynx-js/types": "catalog:"
   },
   "peerDependencies": {
     "@lynx-js/types": "*"

--- a/examples/zustand/package.json
+++ b/examples/zustand/package.json
@@ -27,7 +27,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",
-    "@lynx-js/types": "^3.4.11",
+    "@lynx-js/types": "catalog:",
     "@types/react": "^18.3.25",
     "typescript": "~5.9.3",
     "zustand": "^5.0.8"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
       "@biomejs/biome",
       "dprint"
     ],
+    "overrides": {
+      "@lynx-js/types": "catalog:"
+    },
     "ignoredBuiltDependencies": [
       "core-js"
     ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ catalogs:
       specifier: 0.11.8
       version: 0.11.8
 
+overrides:
+  '@lynx-js/types': 3.4.11
+
 importers:
 
   .:
@@ -64,7 +67,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@rsbuild/plugin-sass':
         specifier: 1.4.0
@@ -92,7 +95,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@rsbuild/plugin-sass':
         specifier: 1.4.0
@@ -117,7 +120,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@rsbuild/plugin-sass':
         specifier: 1.4.0
@@ -145,7 +148,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@types/react':
         specifier: ^18.3.25
@@ -170,7 +173,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@types/react':
         specifier: ^18.3.25
@@ -195,7 +198,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@rsbuild/plugin-sass':
         specifier: 1.4.0
@@ -223,7 +226,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@types/react':
         specifier: ^18.3.25
@@ -248,7 +251,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@rsbuild/plugin-sass':
         specifier: 1.4.0
@@ -276,7 +279,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@types/react':
         specifier: ^18.3.25
@@ -301,7 +304,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@rsbuild/plugin-sass':
         specifier: 1.4.0
@@ -329,7 +332,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@rsbuild/plugin-sass':
         specifier: 1.4.0
@@ -354,7 +357,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@types/react':
         specifier: ^18.3.25
@@ -382,7 +385,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@types/react':
         specifier: ^18.3.25
@@ -410,7 +413,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@types/react':
         specifier: ^18.3.25
@@ -435,7 +438,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@types/react':
         specifier: ^18.3.25
@@ -460,7 +463,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@rsbuild/plugin-sass':
         specifier: 1.4.0
@@ -488,7 +491,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@rsbuild/plugin-sass':
         specifier: 1.4.0
@@ -516,7 +519,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@types/react':
         specifier: ^18.3.25
@@ -541,7 +544,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@rsbuild/plugin-sass':
         specifier: 1.4.0
@@ -569,7 +572,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@types/react':
         specifier: ^18.3.25
@@ -594,7 +597,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@types/react':
         specifier: ^18.3.25
@@ -619,7 +622,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@types/react':
         specifier: ^18.3.25
@@ -644,7 +647,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@types/react':
         specifier: ^18.3.25
@@ -672,7 +675,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@rsbuild/plugin-sass':
         specifier: 1.4.0
@@ -700,7 +703,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@rsbuild/plugin-sass':
         specifier: 1.4.0
@@ -728,7 +731,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@rsbuild/plugin-sass':
         specifier: 1.4.0
@@ -756,7 +759,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@types/react':
         specifier: ^18.3.25
@@ -781,7 +784,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@rsbuild/plugin-sass':
         specifier: 1.4.0
@@ -809,7 +812,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@rsbuild/plugin-sass':
         specifier: 1.4.0
@@ -840,7 +843,7 @@ importers:
         specifier: 0.4.0
         version: 0.4.0(tailwindcss@3.4.18)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@types/react':
         specifier: ^18.3.25
@@ -874,7 +877,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@tanstack/router-plugin':
         specifier: 1.132.31
@@ -899,7 +902,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@rsbuild/plugin-sass':
         specifier: 1.4.0
@@ -927,7 +930,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@rsbuild/plugin-sass':
         specifier: 1.4.0
@@ -955,7 +958,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@rsbuild/plugin-sass':
         specifier: 1.4.0
@@ -980,7 +983,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@types/react':
         specifier: ^18.3.25
@@ -1007,7 +1010,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@types/react':
         specifier: ^18.3.25
@@ -1062,7 +1065,7 @@ importers:
         specifier: 0.9.0
         version: 0.9.0
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@rspack/cli':
         specifier: ^1.5.8
@@ -1084,7 +1087,7 @@ importers:
         version: 1.9.9
     devDependencies:
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
 
   examples/zustand:
@@ -1103,7 +1106,7 @@ importers:
         specifier: 'catalog:'
         version: 0.11.8(@rspack/core@1.6.1(@swc/helpers@0.5.17))(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
-        specifier: ^3.4.11
+        specifier: 3.4.11
         version: 3.4.11
       '@types/react':
         specifier: ^18.3.25
@@ -1687,7 +1690,7 @@ packages:
   '@lynx-js/react@0.114.3':
     resolution: {integrity: sha512-Q4M792DLJdBM3zAJReFrpnMv8VgRUJW5meWi5cuGo+0tPMJc7S1ORqC6wqM3YCnJrcUpGUJY11oAz4gVQ48qBw==}
     peerDependencies:
-      '@lynx-js/types': '*'
+      '@lynx-js/types': 3.4.11
       '@types/react': ^18
     peerDependenciesMeta:
       '@lynx-js/types':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,4 @@ catalog:
   "@lynx-js/rspeedy": "0.11.8"
   "@lynx-js/react": "0.114.3"
   "@lynx-js/react-rsbuild-plugin": "0.11.3"
+  "@lynx-js/types": "3.4.11"


### PR DESCRIPTION
1. use catalog to unify version.
2. override types version to avoid version mismatch (some other package may depends on higher version)