### PR TITLE
feat(desktop): make cursor demos responsive to container size

### DIFF
--- a/.changeset/curvy-geese-juggle.md
+++ b/.changeset/curvy-geese-juggle.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/desktop": patch
+---
+
+Make the desktop cursor demos scale with their container size so they still fit and behave correctly in small iframe embeds.

--- a/examples/desktop/src/cursor/App.css
+++ b/examples/desktop/src/cursor/App.css
@@ -1,7 +1,8 @@
 .Page {
-  width: 100vw;
-  min-height: 100vh;
-  padding: 32px;
+  width: 100%;
+  min-height: 100%;
+  padding: 5%;
+  box-sizing: border-box;
   background:
     radial-gradient(circle at top left, #dbeafe 0%, transparent 28%),
     linear-gradient(180deg, #f8fafc 0%, #e2e8f0 100%);
@@ -11,8 +12,8 @@
   width: 100%;
   max-width: 640px;
   margin: 0 auto;
-  padding: 28px;
-  border-radius: 28px;
+  padding: 4.375%;
+  border-radius: 4.375%;
   background-color: rgba(255, 255, 255, 0.92);
   box-shadow:
     0 24px 60px rgba(15, 23, 42, 0.08),
@@ -20,6 +21,7 @@
   display: flex;
   flex-direction: column;
   gap: 18px;
+  box-sizing: border-box;
 }
 
 .Eyebrow {
@@ -50,13 +52,15 @@
 }
 
 .Button {
-  min-width: 120px;
+  min-width: 96px;
   padding: 14px 16px;
   border-radius: 16px;
   background-color: #eff6ff;
   border: 1px solid #93c5fd;
   align-items: center;
   justify-content: center;
+  flex-grow: 1;
+  box-sizing: border-box;
 }
 
 .ButtonText {

--- a/examples/desktop/src/cursor/App.tsx
+++ b/examples/desktop/src/cursor/App.tsx
@@ -1,3 +1,4 @@
+import { useResponsiveScale } from "../useResponsiveScale";
 import "./App.css";
 
 const cursorPresets = [
@@ -10,21 +11,56 @@ const cursorPresets = [
 ] as const;
 
 export function App() {
-  return (
-    <view className="Page">
-      <view className="Panel">
-        <text className="Eyebrow">CSS cursor</text>
-        <text className="Title">Hover the buttons to preview cursor keywords.</text>
-        <text className="Subtitle">Each button applies its own cursor value.</text>
+  const { handleLayoutChange, scale } = useResponsiveScale({
+    baseWidth: 640,
+    baseHeight: 420,
+    minScale: 0.58,
+  });
+  const pageStyle = {
+    padding: `${32 * scale}px`,
+  };
+  const panelStyle = {
+    padding: `${28 * scale}px`,
+    gap: `${18 * scale}px`,
+    borderRadius: `${28 * scale}px`,
+  };
+  const eyebrowStyle = {
+    fontSize: `${14 * scale}px`,
+    letterSpacing: `${scale}px`,
+  };
+  const titleStyle = {
+    fontSize: `${34 * scale}px`,
+  };
+  const subtitleStyle = {
+    fontSize: `${16 * scale}px`,
+  };
+  const buttonsStyle = {
+    gap: `${12 * scale}px`,
+  };
+  const buttonStyle = {
+    minWidth: `${96 * scale}px`,
+    padding: `${14 * scale}px ${16 * scale}px`,
+    borderRadius: `${16 * scale}px`,
+  };
+  const buttonTextStyle = {
+    fontSize: `${16 * scale}px`,
+  };
 
-        <view className="Buttons">
+  return (
+    <view className="Page" style={pageStyle} bindlayoutchange={handleLayoutChange}>
+      <view className="Panel" style={panelStyle}>
+        <text className="Eyebrow" style={eyebrowStyle}>CSS cursor</text>
+        <text className="Title" style={titleStyle}>Hover the buttons to preview cursor keywords.</text>
+        <text className="Subtitle" style={subtitleStyle}>Each button applies its own cursor value.</text>
+
+        <view className="Buttons" style={buttonsStyle}>
           {cursorPresets.map(cursor => (
             <view
               key={cursor}
               className="Button"
-              style={{ cursor }}
+              style={{ ...buttonStyle, cursor }}
             >
-              <text className="ButtonText">{cursor}</text>
+              <text className="ButtonText" style={buttonTextStyle}>{cursor}</text>
             </view>
           ))}
         </view>

--- a/examples/desktop/src/mouse-cursor/App.css
+++ b/examples/desktop/src/mouse-cursor/App.css
@@ -1,11 +1,13 @@
 .Page {
   display: flex;
   flex: 1;
+  width: 100%;
   min-height: 100%;
   align-items: center;
   justify-content: center;
   position: relative;
   overflow: hidden;
+  box-sizing: border-box;
   background:
     radial-gradient(
       circle at 18% 14%,
@@ -97,9 +99,10 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  width: 980px;
+  width: 100%;
+  max-width: 980px;
   gap: 18px;
-  padding: 34px 0 28px;
+  padding: 28px 0 24px;
 }
 
 .Header {
@@ -114,7 +117,7 @@
 
 .Title {
   color: #f8fafc;
-  font-size: 50px;
+  font-size: 44px;
   font-weight: 800;
   line-height: 1;
 }
@@ -122,10 +125,10 @@
 .Stage {
   position: relative;
   align-self: center;
-  width: 980px;
-  height: 320px;
+  width: 100%;
+  aspect-ratio: 49 / 16;
   overflow: hidden;
-  border-radius: 34px;
+  border-radius: 3.469388%;
   background:
     radial-gradient(
       circle at 18% 30%,
@@ -149,11 +152,11 @@
 
 .DesktopFrame {
   position: absolute;
-  left: 588px;
-  top: 58px;
-  width: 336px;
-  height: 238px;
-  border-radius: 28px;
+  left: 60%;
+  top: 18.125%;
+  width: 34.285714%;
+  height: 74.375%;
+  border-radius: 8.333333%;
   overflow: hidden;
   transition: transform 180ms ease, filter 180ms ease;
 }
@@ -174,10 +177,6 @@
 
 .LogoCard {
   position: absolute;
-  left: 160px;
-  top: 94px;
-  width: 132px;
-  height: 132px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -202,7 +201,7 @@
 }
 
 .LogoImage {
-  width: 100px;
-  height: 100px;
+  width: 75.757576%;
+  height: 75.757576%;
   pointer-events: none;
 }

--- a/examples/desktop/src/mouse-cursor/App.tsx
+++ b/examples/desktop/src/mouse-cursor/App.tsx
@@ -1,14 +1,20 @@
+import { useResponsiveScale } from "../useResponsiveScale";
 import desktopFrame from "./assets/desktop-frame.png";
 import lynxLogo from "./assets/lynx-logo.png";
 import { useDesktopDrag } from "./useDesktopDrag";
 import "./App.css";
 
 export function App() {
+  const { handleLayoutChange, scale } = useResponsiveScale({
+    baseWidth: 980,
+    baseHeight: 420,
+    minScale: 0.56,
+  });
   const {
     desktopHot,
     docked,
     dragging,
-    logoPos,
+    logoCardStyle,
     cancelDrag,
     finishDrag,
     handleDesktopLayout,
@@ -20,10 +26,17 @@ export function App() {
     docked ? "DesktopFrame--occupied" : ""
   }`;
   const logoCardClassName = `LogoCard ${dragging ? "LogoCard--dragging" : ""} ${docked ? "LogoCard--docked" : ""}`;
-  const logoCardStyle = {
-    left: `${logoPos.x}px`,
-    top: `${logoPos.y}px`,
-    cursor: dragging ? "grabbing" : "grab",
+  const posterStyle = {
+    gap: `${18 * scale}px`,
+    paddingTop: `${28 * scale}px`,
+    paddingBottom: `${24 * scale}px`,
+  };
+  const headerStyle = {
+    gap: `${8 * scale}px`,
+    maxWidth: `${760 * scale}px`,
+  };
+  const titleStyle = {
+    fontSize: `${44 * scale}px`,
   };
 
   return (
@@ -32,6 +45,7 @@ export function App() {
       bindmousemove={handleMove}
       bindmouseup={finishDrag}
       bindmouseleave={cancelDrag}
+      bindlayoutchange={handleLayoutChange}
     >
       <view className="PageBackdrop">
         <view className="PageOrb" />
@@ -39,9 +53,9 @@ export function App() {
         <view className="BackdropGlow BackdropGlow--b" />
         <view className="BackdropGlow BackdropGlow--accent" />
       </view>
-      <view className="Poster">
-        <view className="Header">
-          <text className="Title">Bringing Lynx to desktop</text>
+      <view className="Poster" style={posterStyle}>
+        <view className="Header" style={headerStyle}>
+          <text className="Title" style={titleStyle}>Bringing Lynx to desktop</text>
         </view>
 
         <view className="Stage" bindlayoutchange={handleStageLayout}>

--- a/examples/desktop/src/mouse-cursor/useDesktopDrag.ts
+++ b/examples/desktop/src/mouse-cursor/useDesktopDrag.ts
@@ -5,11 +5,43 @@ type Point = { x: number; y: number };
 type Rect = { left: number; top: number; width: number; height: number };
 type TargetId = number | string | null;
 
+const STAGE_BASE = { width: 980, height: 320 };
 const LOGO_SIZE = { width: 132, height: 132 };
 const LOGO_HOME: Point = { x: 160, y: 94 };
+const STAGE_PADDING = { x: 24, y: 24 };
+const DOCK_OFFSET_Y = -15;
 
 function clamp(value: number, min: number, max: number) {
   return Math.max(min, Math.min(max, value));
+}
+
+function scaleX(value: number, stageRect: Rect) {
+  return value * stageRect.width / STAGE_BASE.width;
+}
+
+function scaleY(value: number, stageRect: Rect) {
+  return value * stageRect.height / STAGE_BASE.height;
+}
+
+function toRenderedPoint(point: Point, stageRect: Rect): Point {
+  return {
+    x: scaleX(point.x, stageRect),
+    y: scaleY(point.y, stageRect),
+  };
+}
+
+function toLogicalPoint(point: Point, stageRect: Rect): Point {
+  return {
+    x: point.x * STAGE_BASE.width / stageRect.width,
+    y: point.y * STAGE_BASE.height / stageRect.height,
+  };
+}
+
+function getLogoSize(stageRect: Rect) {
+  return {
+    width: scaleX(LOGO_SIZE.width, stageRect),
+    height: scaleY(LOGO_SIZE.height, stageRect),
+  };
 }
 
 function readTargetId(event: LayoutChangeEvent): TargetId {
@@ -65,18 +97,30 @@ function isInside(rect: Rect, point: Point) {
 }
 
 function getDraggedLogoPosition(point: Point, stageRect: Rect, dragOffset: Point) {
-  return {
-    x: clamp(point.x - dragOffset.x, 24, stageRect.width - LOGO_SIZE.width - 24),
-    y: clamp(point.y - dragOffset.y, 24, stageRect.height - LOGO_SIZE.height - 24),
+  const logoSize = getLogoSize(stageRect);
+  const renderedPosition = {
+    x: clamp(
+      point.x - dragOffset.x,
+      scaleX(STAGE_PADDING.x, stageRect),
+      stageRect.width - logoSize.width - scaleX(STAGE_PADDING.x, stageRect),
+    ),
+    y: clamp(
+      point.y - dragOffset.y,
+      scaleY(STAGE_PADDING.y, stageRect),
+      stageRect.height - logoSize.height - scaleY(STAGE_PADDING.y, stageRect),
+    ),
   };
+  return toLogicalPoint(renderedPosition, stageRect);
 }
 
-function getLogoRect(position: Point): Rect {
+function getLogoRect(position: Point, stageRect: Rect): Rect {
+  const renderedPosition = toRenderedPoint(position, stageRect);
+  const logoSize = getLogoSize(stageRect);
   return {
-    left: position.x,
-    top: position.y,
-    width: LOGO_SIZE.width,
-    height: LOGO_SIZE.height,
+    left: renderedPosition.x,
+    top: renderedPosition.y,
+    width: logoSize.width,
+    height: logoSize.height,
   };
 }
 
@@ -86,8 +130,8 @@ function getRectIntersectionArea(a: Rect, b: Rect) {
   return overlapWidth * overlapHeight;
 }
 
-function shouldDockLogo(position: Point, desktopRect: Rect) {
-  const logoRect = getLogoRect(position);
+function shouldDockLogo(position: Point, stageRect: Rect, desktopRect: Rect) {
+  const logoRect = getLogoRect(position, stageRect);
   const logoCenter = {
     x: logoRect.left + logoRect.width / 2,
     y: logoRect.top + logoRect.height / 2,
@@ -101,11 +145,12 @@ function shouldDockLogo(position: Point, desktopRect: Rect) {
   return overlapRatio >= 0.35;
 }
 
-function getDockedLogoPosition(desktopRect: Rect) {
-  return {
-    x: desktopRect.left + Math.round((desktopRect.width - LOGO_SIZE.width) / 2),
-    y: desktopRect.top + Math.round((desktopRect.height - LOGO_SIZE.height) / 2) - 15,
-  };
+function getDockedLogoPosition(desktopRect: Rect, stageRect: Rect) {
+  const logoSize = getLogoSize(stageRect);
+  return toLogicalPoint({
+    x: desktopRect.left + Math.round((desktopRect.width - logoSize.width) / 2),
+    y: desktopRect.top + Math.round((desktopRect.height - logoSize.height) / 2) + scaleY(DOCK_OFFSET_Y, stageRect),
+  }, stageRect);
 }
 
 export function useDesktopDrag() {
@@ -176,12 +221,13 @@ export function useDesktopDrag() {
     refreshMeasurements(() => {
       if (!stageRectRef.current) return;
       const point = toStagePoint(clientPoint, stageRectRef.current);
+      const renderedLogoPos = toRenderedPoint(logoPosRef.current, stageRectRef.current);
       dragActiveRef.current = true;
       setDragging(true);
       setDocked(false);
       dragOffsetRef.current = {
-        x: point.x - logoPosRef.current.x,
-        y: point.y - logoPosRef.current.y,
+        x: point.x - renderedLogoPos.x,
+        y: point.y - renderedLogoPos.y,
       };
       setDesktopHot(false);
     });
@@ -192,7 +238,7 @@ export function useDesktopDrag() {
     const point = toStagePoint(readClientPoint(event), stageRectRef.current);
     const next = getDraggedLogoPosition(point, stageRectRef.current, dragOffsetRef.current);
     setLogoPosition(next);
-    setDesktopHot(desktopRectRef.current ? shouldDockLogo(next, desktopRectRef.current) : false);
+    setDesktopHot(desktopRectRef.current ? shouldDockLogo(next, stageRectRef.current, desktopRectRef.current) : false);
   };
 
   const finishDrag = (event: MouseEvent) => {
@@ -200,10 +246,12 @@ export function useDesktopDrag() {
     dragActiveRef.current = false;
     const point = toStagePoint(readClientPoint(event), stageRectRef.current);
     const releasePos = getDraggedLogoPosition(point, stageRectRef.current, dragOffsetRef.current);
-    const willDock = desktopRectRef.current ? shouldDockLogo(releasePos, desktopRectRef.current) : false;
+    const willDock = desktopRectRef.current
+      ? shouldDockLogo(releasePos, stageRectRef.current, desktopRectRef.current)
+      : false;
 
     if (willDock && desktopRectRef.current) {
-      setLogoPosition(getDockedLogoPosition(desktopRectRef.current));
+      setLogoPosition(getDockedLogoPosition(desktopRectRef.current, stageRectRef.current));
       setDocked(true);
     } else {
       setLogoPosition(LOGO_HOME);
@@ -223,11 +271,19 @@ export function useDesktopDrag() {
     setDesktopHot(false);
   };
 
+  const logoCardStyle = {
+    left: `${logoPos.x / STAGE_BASE.width * 100}%`,
+    top: `${logoPos.y / STAGE_BASE.height * 100}%`,
+    width: `${LOGO_SIZE.width / STAGE_BASE.width * 100}%`,
+    height: `${LOGO_SIZE.height / STAGE_BASE.height * 100}%`,
+    cursor: dragging ? "grabbing" : "grab",
+  };
+
   return {
     desktopHot,
     docked,
     dragging,
-    logoPos,
+    logoCardStyle,
     cancelDrag,
     finishDrag,
     handleDesktopLayout,

--- a/examples/desktop/src/useResponsiveScale.ts
+++ b/examples/desktop/src/useResponsiveScale.ts
@@ -1,0 +1,37 @@
+import { useState } from "@lynx-js/react";
+import type { LayoutChangeEvent } from "@lynx-js/types";
+
+type ResponsiveScaleOptions = {
+  baseWidth: number;
+  baseHeight: number;
+  maxScale?: number;
+  minScale?: number;
+};
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function useResponsiveScale({
+  baseWidth,
+  baseHeight,
+  maxScale = 1,
+  minScale = 0.5,
+}: ResponsiveScaleOptions) {
+  const [scale, setScale] = useState(1);
+
+  const handleLayoutChange = (event: LayoutChangeEvent) => {
+    const { width, height } = event.detail;
+
+    if (!width || !height) {
+      return;
+    }
+
+    setScale(clamp(Math.min(width / baseWidth, height / baseHeight, maxScale), minScale, maxScale));
+  };
+
+  return {
+    handleLayoutChange,
+    scale,
+  };
+}


### PR DESCRIPTION
## Summary
- make the desktop cursor demos scale with their container instead of assuming a full-size viewport
- keep mouse-cursor drag math aligned with the rendered stage size so dragging and docking still behave correctly in small iframes
- add a changeset for @lynx-example/desktop

## Validation
- pnpm --filter @lynx-example/desktop run build
- pnpm exec dprint check .changeset/curvy-geese-juggle.md examples/desktop/src/useResponsiveScale.ts examples/desktop/src/cursor/App.css examples/desktop/src/cursor/App.tsx examples/desktop/src/mouse-cursor/App.css examples/desktop/src/mouse-cursor/App.tsx examples/desktop/src/mouse-cursor/useDesktopDrag.ts
- pnpm changeset status --verbose --since upstream/main
- pnpm meta-updater --test