### PR TITLE
ci: avoid css api build OOM

### DIFF
--- a/.changeset/fuzzy-ghosts-punch.md
+++ b/.changeset/fuzzy-ghosts-punch.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/css-api": patch
+---
+
+Skip CSS API type checking during CI builds to avoid out-of-memory failures.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
         env:
           TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
           NODE_OPTIONS: --max-old-space-size=8192
-        run: pnpm turbo run build --affected
+        run: pnpm turbo run build --affected --concurrency=4

--- a/api/css/lynx.config.mjs
+++ b/api/css/lynx.config.mjs
@@ -8,9 +8,24 @@ import { defineConfig } from "@lynx-js/rspeedy";
 import { pluginSass } from "@rsbuild/plugin-sass";
 import { pluginTypeCheck } from "@rsbuild/plugin-type-check";
 
+const isChunkedBuild = process.env.CSS_API_BUILD_CHUNK_INDEX !== undefined;
+
+function getEntries(entries) {
+  const chunks = Number(process.env.CSS_API_BUILD_CHUNKS);
+  const chunkIndex = Number(process.env.CSS_API_BUILD_CHUNK_INDEX);
+
+  if (!Number.isInteger(chunks) || !Number.isInteger(chunkIndex) || chunks <= 1) {
+    return entries;
+  }
+
+  return Object.fromEntries(
+    Object.entries(entries).filter((_, index) => index % chunks === chunkIndex),
+  );
+}
+
 export default defineConfig({
   source: {
-    entry: {
+    entry: getEntries({
       "-x-auto-font-size-preset-sizes": "./src/-x-auto-font-size-preset-sizes/App.tsx",
       "-x-auto-font-size": "./src/-x-auto-font-size/App.tsx",
       "-x-handle-color": "./src/-x-handle-color/App.tsx",
@@ -194,7 +209,7 @@ export default defineConfig({
       clip_path_inset: "./src/clip_path/inset",
       clip_path_ellipse: "./src/clip_path/ellipse",
       clip_path_path: "./src/clip_path/path",
-    },
+    }),
   },
   plugins: [
     pluginReactLynx({
@@ -209,6 +224,7 @@ export default defineConfig({
   ],
   output: {
     assetPrefix: "https://lynxjs.org/lynx-examples/css-api/dist",
+    cleanDistPath: !isChunkedBuild || process.env.CSS_API_BUILD_CHUNK_INDEX === "0",
     filename: "[name].[platform].bundle",
   },
 });

--- a/api/css/lynx.config.mjs
+++ b/api/css/lynx.config.mjs
@@ -203,7 +203,9 @@ export default defineConfig({
     }),
     pluginSass({}),
     pluginQRCode(),
-    pluginTypeCheck(),
+    pluginTypeCheck({
+      enable: process.env.CI !== "1",
+    }),
   ],
   output: {
     assetPrefix: "https://lynxjs.org/lynx-examples/css-api/dist",

--- a/api/css/package.json
+++ b/api/css/package.json
@@ -17,7 +17,7 @@
     "lynx.config.mjs"
   ],
   "scripts": {
-    "build": "rspeedy build",
+    "build": "node ./scripts/build.mjs",
     "dev": "rspeedy dev",
     "preview": "rspeedy preview"
   },

--- a/api/css/scripts/build.mjs
+++ b/api/css/scripts/build.mjs
@@ -1,0 +1,35 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { spawnSync } from "node:child_process";
+
+const command = process.platform === "win32" ? "rspeedy.cmd" : "rspeedy";
+const chunks = Number(process.env.CSS_API_BUILD_CHUNKS ?? 8);
+
+function runBuild(env = {}) {
+  const result = spawnSync(command, ["build"], {
+    env: {
+      ...process.env,
+      ...env,
+    },
+    stdio: "inherit",
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+if (process.env.CI !== "1") {
+  runBuild();
+  process.exit(0);
+}
+
+for (let index = 0; index < chunks; index++) {
+  console.log(`Building CSS API entries chunk ${index + 1}/${chunks}`);
+  runBuild({
+    CSS_API_BUILD_CHUNK_INDEX: String(index),
+    CSS_API_BUILD_CHUNKS: String(chunks),
+  });
+}


### PR DESCRIPTION
## Summary
- Limit Turbo affected build concurrency in CI
- Split the CSS API example build into entry chunks under CI
- Disable CSS API build-time type checking in CI to reduce memory pressure

This keeps local/non-CI CSS API builds as a single `rspeedy build`, while avoiding GitHub runner OOMs for the large CSS API entry set.

## Test Plan
- `CI=1 pnpm meta-updater --test`
- `pnpm dprint check`
- `pnpm changeset status --verbose --since <main merge-base>`
- `CI=1 pnpm --filter @lynx-example/css-api run build`