### PR TITLE
chore(external-bundle): include rslib config files in published package

### DIFF
--- a/.changeset/external-bundle-include-rslib-configs.md
+++ b/.changeset/external-bundle-include-rslib-configs.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/external-bundle": patch
+---
+
+Include `*.rslib.config.js` files in the published package so the bundle build configs (`comp.rslib.config.js`, `lodash.rslib.config.js`) are available to consumers.

--- a/examples/external-bundle/package.json
+++ b/examples/external-bundle/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "*.rslib.config.js"
   ],
   "scripts": {
     "build": "pnpm build:bundle && rspeedy build",


### PR DESCRIPTION
## Summary
- Add `*.rslib.config.js` to the `files` field of `@lynx-example/external-bundle` so `comp.rslib.config.js` and `lodash.rslib.config.js` are included when the package is published.
- Add a patch changeset for `@lynx-example/external-bundle`.

## Test plan
- [ ] `pnpm pack` (or `npm pack --dry-run`) inside `examples/external-bundle` lists the rslib config files.
- [ ] CI passes.