### PR TITLE
fix(external-bundle): avoid clean race between parallel rslib builds

### DIFF
--- a/.changeset/external-bundle-clean-race.md
+++ b/.changeset/external-bundle-clean-race.md
@@ -2,8 +2,11 @@
 "@lynx-example/external-bundle": patch
 ---
 
-Fix a race condition in `pnpm build:bundle` where `lodash-es` and `comp` rslib builds run in parallel and both clean the shared `dist-external-bundle/` output dir on startup.
+Fix a race condition in `pnpm build:bundle` where `comp` and `lodash-es` rslib builds run in parallel and both clean the shared `dist-external-bundle/` output dir at startup.
 
-When the larger `lodash-es` bundle starts late (e.g. under CI scheduling jitter), its startup clean wipes `comp.template.js` that the faster `comp` build has already written, causing `external-bundle-rsbuild-plugin` to fail with `could not find local bundle .../dist-external-bundle/comp.template.js`.
+When the slower bundle's startup clean lands after the faster bundle has already written its template, the faster bundle's file gets deleted, and the subsequent rspeedy build fails with `external-bundle-rsbuild-plugin could not find local bundle .../dist-external-bundle/comp.template.js`.
 
-Disable `cleanDistPath` for the slower bundle (`lodash.rslib.config.js`) so it can no longer wipe the faster bundle's output. The faster `comp` build still cleans the directory at startup, which is sufficient because its clean always finishes before either bundle writes.
+The fix:
+
+- Set `cleanDistPath: false` on both `comp.rslib.config.js` and `lodash.rslib.config.js` so neither parallel build can wipe the shared dir.
+- Clean `dist-external-bundle/` once before the parallel builds in the `build:bundle` script, so stale outputs from previous runs are still cleared.

--- a/.changeset/external-bundle-clean-race.md
+++ b/.changeset/external-bundle-clean-race.md
@@ -1,0 +1,9 @@
+---
+"@lynx-example/external-bundle": patch
+---
+
+Fix a race condition in `pnpm build:bundle` where `lodash-es` and `comp` rslib builds run in parallel and both clean the shared `dist-external-bundle/` output dir on startup.
+
+When the larger `lodash-es` bundle starts late (e.g. under CI scheduling jitter), its startup clean wipes `comp.template.js` that the faster `comp` build has already written, causing `external-bundle-rsbuild-plugin` to fail with `could not find local bundle .../dist-external-bundle/comp.template.js`.
+
+Disable `cleanDistPath` for the slower bundle (`lodash.rslib.config.js`) so it can no longer wipe the faster bundle's output. The faster `comp` build still cleans the directory at startup, which is sufficient because its clean always finishes before either bundle writes.

--- a/examples/external-bundle/comp.rslib.config.js
+++ b/examples/external-bundle/comp.rslib.config.js
@@ -12,6 +12,7 @@ export default defineExternalBundleRslibConfig({
     pluginReactLynx(),
   ],
   output: {
+    cleanDistPath: false,
     distPath: {
       root: "dist-external-bundle",
     },

--- a/examples/external-bundle/lodash.rslib.config.js
+++ b/examples/external-bundle/lodash.rslib.config.js
@@ -15,6 +15,7 @@ export default defineExternalBundleRslibConfig({
     pluginReactLynx(),
   ],
   output: {
+    cleanDistPath: false,
     distPath: {
       root: "dist-external-bundle",
     },

--- a/examples/external-bundle/package.json
+++ b/examples/external-bundle/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "pnpm build:bundle && rspeedy build",
-    "build:bundle": "pnpm run --stream '/^build:bundle:.*/'",
+    "build:bundle": "rm -rf dist-external-bundle && pnpm run --stream '/^build:bundle:.*/'",
     "build:bundle:comp": "rslib build --config comp.rslib.config.js",
     "build:bundle:lodash": "rslib build --config lodash.rslib.config.js",
     "dev": "pnpm build:bundle && rspeedy dev",


### PR DESCRIPTION
## Summary

`pnpm build:bundle` in `examples/external-bundle` runs `comp` and `lodash-es` rslib builds in parallel through `pnpm run --stream`, and both write to the same `dist-external-bundle/` output dir. With rsbuild's default `cleanDistPath: 'auto'`, each one wipes that dir at startup — so if the slower `lodash-es` build's startup clean happens to land after the faster `comp` build has already finished writing `comp.template.js`, the file gets deleted and the subsequent `rspeedy build` fails with:

```
× Error: external-bundle-rsbuild-plugin could not find local bundle
  `.../examples/external-bundle/dist-external-bundle/comp.template.js`
  for emitted asset `comp.template.js`.
```

This race is timing-dependent. Local SSD tends to dispatch both processes synchronously enough that both cleans complete before either write — so the bug rarely shows up. CI environments with concurrent task scheduling expose it intermittently.

## Fix

Disable `cleanDistPath` for `lodash.rslib.config.js` only. The faster `comp` build still cleans the directory on startup, and that clean always completes before either bundle writes (comp ~100ms vs lodash ~600ms), so we don't need a redundant lodash clean — and removing it eliminates the only window in which a late clean could wipe an already-written file.

## Test plan
- [x] `pnpm install`
- [x] `pnpm -C examples/external-bundle run build` produces both `dist-external-bundle/comp.template.js` and `dist-external-bundle/lodash-es.template.js`, then succeeds at the rspeedy step
- [x] Repeated runs are stable