### PR TITLE
feat: add CSS API demo for line-based auto font sizing

### DIFF
--- a/.changeset/green-pets-drive.md
+++ b/.changeset/green-pets-drive.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/css-api": patch
+---
+
+feat: add CSS API demo for line-based auto font sizing

--- a/api/css/lynx.config.mjs
+++ b/api/css/lynx.config.mjs
@@ -26,6 +26,7 @@ function getEntries(entries) {
 export default defineConfig({
   source: {
     entry: getEntries({
+      "-x-auto-font-size-line-ranges": "./src/-x-auto-font-size-line-ranges/App.tsx",
       "-x-auto-font-size-preset-sizes": "./src/-x-auto-font-size-preset-sizes/App.tsx",
       "-x-auto-font-size": "./src/-x-auto-font-size/App.tsx",
       "-x-handle-color": "./src/-x-handle-color/App.tsx",

--- a/api/css/src/-x-auto-font-size-line-ranges/App.tsx
+++ b/api/css/src/-x-auto-font-size-line-ranges/App.tsx
@@ -1,0 +1,25 @@
+import { root } from "@lynx-js/react";
+
+import "./index.scss";
+
+const samples = [
+  "Short title",
+  "A medium title that wraps into two lines",
+  "A very long title that wraps into three lines and uses the last line range rule",
+];
+
+const XAutoFontSizeLineRanges = () => {
+  return (
+    <view className="page">
+      {samples.map((sample) => (
+        <view key={sample} className="card">
+          <text className="title" text-maxline="3">
+            {sample}
+          </text>
+        </view>
+      ))}
+    </view>
+  );
+};
+
+root.render(<XAutoFontSizeLineRanges />);

--- a/api/css/src/-x-auto-font-size-line-ranges/index.scss
+++ b/api/css/src/-x-auto-font-size-line-ranges/index.scss
@@ -1,0 +1,24 @@
+.page {
+  margin: 24px;
+  flex-direction: column;
+  row-gap: 12px;
+  background-color: #f8fafc;
+}
+
+.card {
+  width: 210px;
+  padding: 16px;
+  border-radius: 12px;
+  background-color: #ffffff;
+}
+
+.title {
+  width: 180px;
+  font-size: 15px;
+  color: #1f2937;
+  -x-auto-font-size: true;
+  -x-auto-font-size-line-ranges:
+    line-range(1, 18px, 22px),
+    line-range(2, 16px, 18px),
+    line-range(3 to infinity, 14px);
+}


### PR DESCRIPTION
Add a focused api/css example for -x-auto-font-size-line-ranges so the new text sizing behavior can be verified directly through the CSS API demos.