### PR TITLE
feat: add WebAssembly example

### DIFF
--- a/.changeset/webassembly-example.md
+++ b/.changeset/webassembly-example.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/webassembly": minor
+---
+
+Add a WebAssembly example that runs an add function in Lynx.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This repository is intended to showcase examples of Lynx.
   - [`local-storage`]: An example shows how to use local storage in Lynx
   - [`networking`]: An example shows Lynx networking abilities
   - [`react-lifecycle`]: An example shows ReactLynx lifecycle
+  - [`webassembly`]: An example shows how to run WebAssembly in Lynx
 - Web Platform
   - [`basic-usage`]: An example shows how to use Lynx Web Platform
 - UI Components
@@ -103,6 +104,7 @@ This repository is intended to showcase examples of Lynx.
 [`tanstack-router`]: ./examples/tanstack-router
 [`text`]: ./examples/text
 [`webview`]: ./examples/webview
+[`webassembly`]: ./examples/webassembly
 [`textarea`]: ./examples/textarea
 [`title-bar-view`]: ./examples/title-bar-view
 [`tutorial-gallery`]: ./examples/Gallery

--- a/examples/webassembly/README.md
+++ b/examples/webassembly/README.md
@@ -1,0 +1,27 @@
+# WebAssembly
+
+This example runs a minimal WebAssembly module in the Lynx background runtime.
+
+Tap the button in LynxExplorer to calculate `1 + 2`. The exported `add` function comes from WebAssembly bytes and is loaded with the constructor-based API:
+
+```ts
+const module = new WebAssembly.Module(wasmBytes);
+const instance = new WebAssembly.Instance(module);
+```
+
+## Getting Started
+
+Install dependencies from the repository root:
+
+```bash
+corepack enable
+pnpm install
+```
+
+Then run the example:
+
+```bash
+pnpm --filter @lynx-example/webassembly run dev
+```
+
+Scan the QRCode in the terminal with your LynxExplorer App to see the result.

--- a/examples/webassembly/lynx.config.ts
+++ b/examples/webassembly/lynx.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "@lynx-js/rspeedy";
+
+import { pluginQRCode } from "@lynx-js/qrcode-rsbuild-plugin";
+import { pluginReactLynx } from "@lynx-js/react-rsbuild-plugin";
+import { pluginTypeCheck } from "@rsbuild/plugin-type-check";
+
+export default defineConfig({
+  plugins: [
+    pluginQRCode(),
+    pluginReactLynx(),
+    pluginTypeCheck(),
+  ],
+  output: {
+    filename: "[name].[platform].bundle",
+  },
+});

--- a/examples/webassembly/package.json
+++ b/examples/webassembly/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@lynx-example/webassembly",
+  "version": "0.1.0",
+  "description": "An example shows how to run WebAssembly in Lynx",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lynx-family/lynx-examples.git",
+    "directory": "examples/webassembly"
+  },
+  "author": "Lynx Authors",
+  "type": "module",
+  "files": [
+    "dist",
+    "src",
+    "lynx.config.ts"
+  ],
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev",
+    "preview": "rspeedy preview"
+  },
+  "dependencies": {
+    "@lynx-js/react": "catalog:"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
+    "@lynx-js/react-rsbuild-plugin": "catalog:",
+    "@lynx-js/rspeedy": "catalog:",
+    "@lynx-js/types": "catalog:",
+    "@types/react": "^18.3.28",
+    "typescript": "~5.9.3"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/examples/webassembly/src/App.css
+++ b/examples/webassembly/src/App.css
@@ -1,0 +1,86 @@
+:root {
+  background-color: #f6f8fb;
+}
+
+text {
+  color: #17202a;
+}
+
+.App {
+  min-height: 100vh;
+  padding: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(180deg, #f8fbff 0%, #edf3f7 100%);
+}
+
+.Panel {
+  width: 100%;
+  max-width: 360px;
+  padding: 28px;
+  border-radius: 8px;
+  background-color: #ffffff;
+  box-shadow: 0 10px 30px rgba(18, 35, 55, 0.12);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.Eyebrow {
+  font-size: 13px;
+  font-weight: 700;
+  color: #476377;
+}
+
+.Title {
+  margin-top: 12px;
+  font-size: 48px;
+  line-height: 54px;
+  font-weight: 800;
+}
+
+.Formula {
+  margin-top: 8px;
+  font-size: 16px;
+  line-height: 22px;
+  color: #526575;
+}
+
+.Button {
+  margin-top: 28px;
+  height: 52px;
+  border-radius: 8px;
+  background-color: #176f8f;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ButtonText {
+  color: #ffffff;
+  font-size: 17px;
+  font-weight: 700;
+}
+
+.ResultBox {
+  margin-top: 22px;
+  padding: 18px;
+  border-radius: 8px;
+  border: 1px solid #d5e1e8;
+  display: flex;
+  flex-direction: column;
+}
+
+.ResultLabel {
+  font-size: 13px;
+  color: #66808f;
+}
+
+.ResultValue {
+  margin-top: 8px;
+  font-size: 28px;
+  line-height: 34px;
+  font-weight: 800;
+  color: #111827;
+}

--- a/examples/webassembly/src/App.tsx
+++ b/examples/webassembly/src/App.tsx
@@ -1,0 +1,45 @@
+import { useCallback, useState } from "@lynx-js/react";
+
+import { addWithWasm } from "./addWasm.js";
+
+import "./App.css";
+
+export function App() {
+  const [result, setResult] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const calculate = useCallback(() => {
+    "background-only";
+    setError(null);
+
+    try {
+      setResult(addWithWasm(1, 2));
+    } catch (err) {
+      setResult(null);
+      setError(err instanceof Error ? err.message : "Failed to run WebAssembly");
+    }
+  }, []);
+
+  return (
+    <page>
+      <view className="App">
+        <view className="Panel">
+          <text className="Eyebrow">WebAssembly on Lynx</text>
+          <text className="Title">1 + 2</text>
+          <text className="Formula">Calculated by a Wasm add function</text>
+
+          <view className="Button" bindtap={calculate}>
+            <text className="ButtonText">Run add(1, 2)</text>
+          </view>
+
+          <view className="ResultBox">
+            <text className="ResultLabel">Result</text>
+            <text className="ResultValue">
+              {error ?? (result == null ? "Tap to calculate" : String(result))}
+            </text>
+          </view>
+        </view>
+      </view>
+    </page>
+  );
+}

--- a/examples/webassembly/src/addWasm.ts
+++ b/examples/webassembly/src/addWasm.ts
@@ -1,0 +1,45 @@
+// dprint-ignore
+const addWasmBytes = new Uint8Array([
+  // Equivalent WAT:
+  // (module
+  //   (func $add (param i32 i32) (result i32)
+  //     local.get 0
+  //     local.get 1
+  //     i32.add)
+  //   (export "add" (func $add)))
+
+  // Wasm module header: magic number and version.
+  0x00, 0x61, 0x73, 0x6d,
+  0x01, 0x00, 0x00, 0x00,
+
+  // Type section: (i32, i32) -> i32.
+  0x01, 0x07, 0x01,
+  0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f,
+
+  // Function section: one function using type index 0.
+  0x03, 0x02, 0x01, 0x00,
+
+  // Export section: export function 0 as "add".
+  0x07, 0x07, 0x01,
+  0x03, 0x61, 0x64, 0x64,
+  0x00, 0x00,
+
+  // Code section: local.get 0; local.get 1; i32.add.
+  0x0a, 0x09, 0x01, 0x07, 0x00,
+  0x20, 0x00,
+  0x20, 0x01,
+  0x6a,
+  0x0b,
+]);
+
+type AddExports = {
+  add: (left: number, right: number) => number;
+};
+
+export function addWithWasm(left: number, right: number): number {
+  const module = new WebAssembly.Module(addWasmBytes);
+  const instance = new WebAssembly.Instance(module);
+  const exports = instance.exports as AddExports;
+
+  return exports.add(left, right);
+}

--- a/examples/webassembly/src/index.tsx
+++ b/examples/webassembly/src/index.tsx
@@ -1,0 +1,9 @@
+import { root } from "@lynx-js/react";
+
+import { App } from "./App.js";
+
+root.render(<App />);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/webassembly/src/rspeedy-env.d.ts
+++ b/examples/webassembly/src/rspeedy-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@lynx-js/rspeedy/client" />

--- a/examples/webassembly/tsconfig.json
+++ b/examples/webassembly/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "@lynx-js/react",
+
+    "module": "node16",
+    "moduleResolution": "node16",
+
+    "strict": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+  },
+  "exclude": ["dist/"],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1443,6 +1443,31 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  examples/webassembly:
+    dependencies:
+      '@lynx-js/react':
+        specifier: 'catalog:'
+        version: 0.121.0(@lynx-js/types@3.9.0)(@types/react@18.3.28)
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.4.7
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.16.2(@lynx-js/react@0.121.0(@lynx-js/types@3.9.0)(@types/react@18.3.28))(tslib@2.8.1)(webpack@5.101.3)
+      '@lynx-js/rspeedy':
+        specifier: 'catalog:'
+        version: 0.14.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(typescript@5.9.3)(webpack@5.101.3)
+      '@lynx-js/types':
+        specifier: 3.9.0
+        version: 3.9.0
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+
   examples/webview:
     dependencies:
       '@lynx-js/react':


### PR DESCRIPTION
## Summary

- Add a new `@lynx-example/webassembly` example package.
- Demonstrate running a minimal WebAssembly `add(1, 2)` function in the Lynx background runtime.
- Document the example and add it to the root README example list.
- Add a changeset for the new publishable example package.

## Validation

- `pnpm meta-updater --test`
- `pnpm dprint check README.md .changeset/webassembly-example.md examples/webassembly/package.json examples/webassembly/lynx.config.ts examples/webassembly/tsconfig.json examples/webassembly/README.md examples/webassembly/src/index.tsx examples/webassembly/src/App.tsx examples/webassembly/src/addWasm.ts examples/webassembly/src/App.css examples/webassembly/src/rspeedy-env.d.ts`
- `pnpm changeset status --verbose --since e52a5726d8320d5b1d3595b597fa96c7c55935ba`
- `pnpm --filter @lynx-example/webassembly run build`