### PR TITLE
[codex] Add Markdown example

### DIFF
--- a/.changeset/soft-markdown.md
+++ b/.changeset/soft-markdown.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/markdown": minor
+---
+
+Add Markdown element examples with a separate entry for each runnable snippet covering styles, inline views, images, text marks, truncation, typewriter animation, and text selection.

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ This repository is intended to showcase examples of Lynx.
   - [`viewpager`]: An example shows how to use `<viewpager>` in Lynx
   - [`title-bar-view`]: An example shows how to use `<title-bar-view>` in Lynx
   - [`native-element`]: An example about using native element in Lynx
-- XElement
   - [`input`]: An example shows how to use input
   - [`textarea`]: An example shows how to use textarea
   - [`overlay`]: An example shows how to use overlay
   - [`svg`]: An example shows how to use svg
+  - [`markdown`]: An example show how to use markdown
 - Styling
   - [`animation`]: Examples for using animation
   - [`css`]: Examples for using different CSS

--- a/examples/markdown/README.md
+++ b/examples/markdown/README.md
@@ -1,0 +1,49 @@
+## Rspeedy project
+
+This is a ReactLynx project bootstrapped with `create-rspeedy`.
+
+## Getting Started
+
+First, install the dependencies:
+
+```bash
+pnpm install
+```
+
+Then, run the development server:
+
+```bash
+pnpm run dev
+```
+
+Scan the QRCode in the terminal with your LynxExplorer App to see the result.
+
+This example exposes one entry for each Markdown snippet:
+
+```text
+basic
+style
+link_style
+span_style
+paragraph_style
+image
+image_size
+image_caption
+image_caption_style
+gif
+inline_view
+span_mark
+text_mark_attachments
+truncation
+truncation_text
+truncation_view
+typewriter
+typewriter_cursor
+typewriter_keep_cursor
+typewriter_mask
+text_selection
+selection_menu
+selection_select_all
+selection_copy
+selection_paragraph
+```

--- a/examples/markdown/lynx.config.ts
+++ b/examples/markdown/lynx.config.ts
@@ -1,0 +1,54 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from "@lynx-js/rspeedy";
+
+import { pluginQRCode } from "@lynx-js/qrcode-rsbuild-plugin";
+import { pluginReactLynx } from "@lynx-js/react-rsbuild-plugin";
+import { pluginTypeCheck } from "@rsbuild/plugin-type-check";
+
+export default defineConfig({
+  source: {
+    entry: {
+      basic: "./src/basic/index.tsx",
+      gif: "./src/gif/index.tsx",
+      image: "./src/image/index.tsx",
+      image_caption: "./src/image_caption/index.tsx",
+      image_caption_style: "./src/image_caption_style/index.tsx",
+      image_size: "./src/image_size/index.tsx",
+      inline_view: "./src/inline_view/index.tsx",
+      link_style: "./src/link_style/index.tsx",
+      paragraph_style: "./src/paragraph_style/index.tsx",
+      selection_copy: "./src/selection_copy/index.tsx",
+      selection_menu: "./src/selection_menu/index.tsx",
+      selection_paragraph: "./src/selection_paragraph/index.tsx",
+      selection_select_all: "./src/selection_select_all/index.tsx",
+      span_mark: "./src/span_mark/index.tsx",
+      span_style: "./src/span_style/index.tsx",
+      style: "./src/style/index.tsx",
+      text_mark_attachments: "./src/text_mark_attachments/index.tsx",
+      text_selection: "./src/text_selection/index.tsx",
+      truncation: "./src/truncation/index.tsx",
+      truncation_text: "./src/truncation_text/index.tsx",
+      truncation_view: "./src/truncation_view/index.tsx",
+      typewriter: "./src/typewriter/index.tsx",
+      typewriter_cursor: "./src/typewriter_cursor/index.tsx",
+      typewriter_keep_cursor: "./src/typewriter_keep_cursor/index.tsx",
+      typewriter_mask: "./src/typewriter_mask/index.tsx",
+    },
+  },
+  plugins: [
+    pluginQRCode(),
+    pluginReactLynx(),
+    pluginTypeCheck(),
+  ],
+  output: {
+    assetPrefix: "https://lynxjs.org/lynx-examples/markdown/dist",
+    filename: "[name].[platform].bundle",
+  },
+  environments: {
+    web: {},
+    lynx: {},
+  },
+});

--- a/examples/markdown/package.json
+++ b/examples/markdown/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@lynx-example/markdown",
+  "version": "0.0.0",
+  "description": "An example shows how to use `<markdown>` in Lynx",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lynx-family/lynx-examples.git",
+    "directory": "examples/markdown"
+  },
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
+  "type": "module",
+  "files": [
+    "dist/",
+    "src/",
+    "lynx.config.ts"
+  ],
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev",
+    "preview": "rspeedy preview"
+  },
+  "dependencies": {
+    "@lynx-js/react": "catalog:"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
+    "@lynx-js/react-rsbuild-plugin": "catalog:",
+    "@lynx-js/rspeedy": "catalog:",
+    "@lynx-js/types": "catalog:",
+    "@types/react": "^18.3.28",
+    "typescript": "~5.9.3"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/examples/markdown/src/App.css
+++ b/examples/markdown/src/App.css
@@ -1,0 +1,115 @@
+.page {
+  width: 100%;
+  height: 100%;
+  background-color: #f6f7f4;
+  padding: 16px;
+}
+
+.title {
+  color: #10201b;
+  font-size: 28px;
+  font-weight: 700;
+  margin-bottom: 12px;
+}
+
+.snippet-card {
+  background-color: #ffffff;
+  border: 1px solid #d9e2dd;
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.snippet-title {
+  color: #254139;
+  font-size: 17px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.markdown-box {
+  background-color: #ffffff;
+  border-radius: 6px;
+  padding: 10px;
+}
+
+.plain-surface {
+  background-color: #ffffff;
+  min-height: 100%;
+  padding: 12px;
+}
+
+.inline-mark {
+  vertical-align: center;
+}
+
+.inline-mark-text {
+  color: linear-gradient(90deg, #2a7b9b 0%, #57c785 50%, #eddd53 100%);
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.truncation-view {
+  align-items: center;
+  background-color: #e6f2ee;
+  border: 1px solid #77aa9a;
+  border-radius: 6px;
+  justify-content: center;
+  padding: 2px 8px;
+  vertical-align: center;
+}
+
+.truncation-text {
+  color: #20594a;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.cursor {
+  background-color: #1d6f5d;
+  border-radius: 4px;
+  height: 18px;
+  width: 8px;
+}
+
+.selection-area {
+  min-height: 150px;
+  overflow: visible;
+  position: relative;
+}
+
+.selection-menu {
+  height: 30px;
+  position: absolute;
+  width: 116px;
+  z-index: 2;
+}
+
+.menu-inner {
+  align-items: center;
+  background-color: #2c3632;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: row;
+  height: 30px;
+  justify-content: center;
+}
+
+.menu-button {
+  color: #ffffff;
+  flex-shrink: 0;
+  font-size: 12px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.menu-divider {
+  background-color: rgba(255, 255, 255, 0.35);
+  height: 18px;
+  width: 1px;
+}
+
+.copied-text {
+  color: #577067;
+  font-size: 12px;
+  margin-top: 8px;
+}

--- a/examples/markdown/src/basic/index.tsx
+++ b/examples/markdown/src/basic/index.tsx
@@ -1,0 +1,19 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+
+function App() {
+  const content = `
+this is a **Markdown**!!
+`;
+
+  return (
+    <view className="plain-surface">
+      <markdown content={content} />
+    </view>
+  );
+}
+
+renderExample("Basic", <App />);

--- a/examples/markdown/src/common.tsx
+++ b/examples/markdown/src/common.tsx
@@ -1,0 +1,23 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root } from "@lynx-js/react";
+import type { ReactNode } from "react";
+
+import "./App.css";
+
+export function renderExample(title: string, children: ReactNode) {
+  root.render(
+    <scroll-view scroll-orientation="vertical" className="page">
+      <text className="title">Markdown: {title}</text>
+      <view className="snippet-card">
+        {children}
+      </view>
+    </scroll-view>,
+  );
+
+  if (import.meta.webpackHot) {
+    import.meta.webpackHot.accept();
+  }
+}

--- a/examples/markdown/src/gif/index.tsx
+++ b/examples/markdown/src/gif/index.tsx
@@ -1,0 +1,25 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+
+const gifUrl = "https://upload.wikimedia.org/wikipedia/commons/3/32/Earth_rotation.gif";
+
+function App() {
+  const content = `
+gif:
+
+![](${gifUrl})
+  `;
+
+  return (
+    <view className="plain-surface">
+      <markdown content={content} enable-gif={true}>
+        {" "}
+      </markdown>
+    </view>
+  );
+}
+
+renderExample("GIF", <App />);

--- a/examples/markdown/src/image/index.tsx
+++ b/examples/markdown/src/image/index.tsx
@@ -1,0 +1,22 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+
+const imageUrl = "https://upload.wikimedia.org/wikipedia/commons/b/be/Grapefruit_free.jpg";
+
+function App() {
+  const content = `
+image:
+![alt text](${imageUrl})
+  `;
+
+  return (
+    <view className="plain-surface">
+      <markdown content={content}></markdown>
+    </view>
+  );
+}
+
+renderExample("Image", <App />);

--- a/examples/markdown/src/image_caption/index.tsx
+++ b/examples/markdown/src/image_caption/index.tsx
@@ -1,0 +1,23 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+
+const imageUrl = "https://upload.wikimedia.org/wikipedia/commons/b/be/Grapefruit_free.jpg";
+
+function App() {
+  const content = `
+image:
+
+![alt text](${imageUrl} width=100 height=100 "a grapefruit")
+  `;
+
+  return (
+    <view className="plain-surface">
+      <markdown content={content}></markdown>
+    </view>
+  );
+}
+
+renderExample("Image Caption", <App />);

--- a/examples/markdown/src/image_caption_style/index.tsx
+++ b/examples/markdown/src/image_caption_style/index.tsx
@@ -1,0 +1,33 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+import type { MarkdownStyle } from "../intrinsic-element.js";
+
+const imageUrl = "https://upload.wikimedia.org/wikipedia/commons/b/be/Grapefruit_free.jpg";
+
+function App() {
+  const content = `
+image:
+
+![alt text](${imageUrl} width=100 height=100 "a grapefruit")
+  `;
+  const style: MarkdownStyle = {
+    imageCaption: {
+      color: "808080",
+      fontSize: 13,
+      textAlign: "left",
+    },
+  };
+
+  return (
+    <view className="plain-surface">
+      <markdown content={content} markdown-style={style}>
+        {" "}
+      </markdown>
+    </view>
+  );
+}
+
+renderExample("Image Caption Style", <App />);

--- a/examples/markdown/src/image_size/index.tsx
+++ b/examples/markdown/src/image_size/index.tsx
@@ -1,0 +1,23 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+
+const imageUrl = "https://upload.wikimedia.org/wikipedia/commons/b/be/Grapefruit_free.jpg";
+
+function App() {
+  const content = `
+image:
+
+![alt text](${imageUrl} width=100 height=100)
+  `;
+
+  return (
+    <view className="plain-surface">
+      <markdown content={content}></markdown>
+    </view>
+  );
+}
+
+renderExample("Image Size", <App />);

--- a/examples/markdown/src/inline_view/index.tsx
+++ b/examples/markdown/src/inline_view/index.tsx
@@ -1,0 +1,31 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+import type { MarkdownStyle } from "../intrinsic-element.js";
+
+function App() {
+  const content = `
+this is a ![](inlineview://mkd)!!
+  `;
+  const style: MarkdownStyle = {
+    normalText: {
+      fontSize: 20,
+    },
+  };
+
+  return (
+    <view className="plain-surface">
+      <markdown content={content} markdown-style={style}>
+        <view id="mkd" className="inline-mark" flatten={false}>
+          <text className="inline-mark-text">
+            Markdown
+          </text>
+        </view>
+      </markdown>
+    </view>
+  );
+}
+
+renderExample("Inline View", <App />);

--- a/examples/markdown/src/intrinsic-element.d.ts
+++ b/examples/markdown/src/intrinsic-element.d.ts
@@ -1,0 +1,104 @@
+import type * as Lynx from "@lynx-js/types";
+import type { ReactNode } from "react";
+
+type MarkdownStyle = Record<string, Record<string, unknown>>;
+type MarkdownEffect = Record<string, unknown>;
+
+interface MarkdownRect {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  width: number;
+  height: number;
+}
+
+interface MarkdownTextBoundingRect {
+  boundingRect: MarkdownRect;
+  boxes: MarkdownRect[];
+}
+
+interface MarkdownLineStyle {
+  lineType: "solid" | "dashed";
+  color: string;
+  width: string | number;
+}
+
+interface MarkdownMarkAttachment {
+  startIndex: number;
+  endIndex: number;
+  indexType: "source" | "parsed";
+  id?: string;
+  clickable?: boolean;
+  style: {
+    color?: string;
+    borderBottom?: MarkdownLineStyle;
+  };
+}
+
+interface MarkdownSelectionChangeEvent {
+  start: number;
+  end: number;
+  direction: "forward" | "backward" | "none";
+}
+
+declare module "@lynx-js/types" {
+  interface IntrinsicElements extends Lynx.IntrinsicElements {
+    markdown: {
+      className?: string;
+      id?: string;
+      style?: string | Lynx.CSSProperties;
+      children?: ReactNode;
+      content: string;
+      "content-id"?: string;
+      "markdown-style"?: MarkdownStyle;
+      "animation-type"?: "none" | "typewriter";
+      "animation-velocity"?: number;
+      "text-maxline"?: number;
+      "initial-animation-step"?: number;
+      "content-complete"?: boolean;
+      "typewriter-dynamic-height"?: boolean;
+      "text-selection"?: boolean;
+      "text-mark-attachments"?: MarkdownMarkAttachment[];
+      "content-range"?: number[];
+      "markdown-effect"?: MarkdownEffect;
+      "typewriter-height-transition-duration"?: number;
+      "enable-gif"?: boolean;
+      overflow?: "ellipsis" | "clip";
+      binddrawStart?: (e: Lynx.BaseEvent) => void;
+      binddrawEnd?: (e: Lynx.BaseEvent) => void;
+      bindanimationStep?: (
+        e: Lynx.BaseEvent<
+          "bindanimationStep",
+          { animationStep: number; maxAnimationStep: number }
+        >,
+      ) => void;
+      bindoverflow?: (
+        e: Lynx.BaseEvent<
+          "bindoverflow",
+          { type: "ellipsis" | "clip" }
+        >,
+      ) => void;
+      bindlink?: (
+        e: Lynx.BaseEvent<"bindlink", { url: string; content: string }>,
+      ) => void;
+      bindselectionchange?: (
+        e: Lynx.BaseEvent<
+          "bindselectionchange",
+          MarkdownSelectionChangeEvent
+        >,
+      ) => void;
+      bindimageTap?: (
+        e: Lynx.BaseEvent<"bindimageTap", { url: string }>,
+      ) => void;
+      bindparseEnd?: (
+        e: Lynx.BaseEvent<"bindparseEnd", { id: string }>,
+      ) => void;
+      bindtextClick?: (
+        e: Lynx.BaseEvent<"bindtextClick", { id: string }>,
+      ) => void;
+    };
+  }
+}
+
+export type { MarkdownEffect, MarkdownMarkAttachment, MarkdownStyle, MarkdownTextBoundingRect };

--- a/examples/markdown/src/link_style/index.tsx
+++ b/examples/markdown/src/link_style/index.tsx
@@ -1,0 +1,27 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+import type { MarkdownStyle } from "../intrinsic-element.js";
+
+function App() {
+  const content = `
+this is [link1](url1).
+
+this is [link2](url1).
+`;
+  const style: MarkdownStyle = {
+    link: {
+      color: "ff0000",
+    },
+  };
+
+  return (
+    <view className="plain-surface">
+      <markdown content={content} markdown-style={style} />
+    </view>
+  );
+}
+
+renderExample("Link Style", <App />);

--- a/examples/markdown/src/paragraph_style/index.tsx
+++ b/examples/markdown/src/paragraph_style/index.tsx
@@ -1,0 +1,30 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+import type { MarkdownStyle } from "../intrinsic-element.js";
+
+function App() {
+  const content = `
+<p class="center">paragraph alignment is center.</p>
+
+<p class="right">paragraph alignment is right.</p>
+`;
+  const style: MarkdownStyle = {
+    ".center": {
+      textAlign: "center",
+    },
+    ".right": {
+      textAlign: "right",
+    },
+  };
+
+  return (
+    <view className="plain-surface">
+      <markdown content={content} markdown-style={style} />
+    </view>
+  );
+}
+
+renderExample("Paragraph Style", <App />);

--- a/examples/markdown/src/rspeedy-env.d.ts
+++ b/examples/markdown/src/rspeedy-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@lynx-js/rspeedy/client" />

--- a/examples/markdown/src/selection_copy/index.tsx
+++ b/examples/markdown/src/selection_copy/index.tsx
@@ -1,0 +1,119 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { useState } from "@lynx-js/react";
+
+import type * as Lynx from "@lynx-js/types";
+import { renderExample } from "../common.js";
+import type { MarkdownTextBoundingRect } from "../intrinsic-element.js";
+
+function App() {
+  const content = `
+this is a **Markdown**!!
+
+this is a **Markdown**!!
+
+this is a **Markdown**!!
+  `;
+  const [menuVisible, setMenuVisible] = useState<"hidden" | "visible">(
+    "hidden",
+  );
+  const [topOffset, setTopOffset] = useState(0);
+  const [leftOffset, setLeftOffset] = useState(0);
+  const [selectedText, setSelectedText] = useState("");
+
+  const clearSelection = () => {
+    lynx
+      .createSelectorQuery()
+      .select("#markdown")
+      .invoke({
+        method: "setTextSelection",
+        params: {
+          startX: -1,
+          startY: -1,
+          endX: -1,
+          endY: -1,
+        },
+      })
+      .exec();
+  };
+
+  const onSelectionChange = (
+    params: Lynx.BaseEvent<
+      "bindselectionchange",
+      { start: number; end: number }
+    >,
+  ) => {
+    const start = params.detail.start;
+    const end = params.detail.end;
+    if (start === -1) {
+      setMenuVisible("hidden");
+      return;
+    }
+
+    setMenuVisible("visible");
+    lynx
+      .createSelectorQuery()
+      .select("#markdown")
+      .invoke({
+        method: "getTextBoundingRect",
+        params: {
+          start,
+          end,
+        },
+        success(res: MarkdownTextBoundingRect) {
+          setLeftOffset(res.boundingRect.left + res.boundingRect.width / 2 - 30);
+          setTopOffset(res.boundingRect.top + res.boundingRect.height / 2 - 10);
+        },
+      })
+      .exec();
+  };
+
+  const onCopy = () => {
+    lynx
+      .createSelectorQuery()
+      .select("#markdown")
+      .invoke({
+        method: "getSelectedText",
+        success(res: { selectedText: string }) {
+          console.log("selected text: " + res.selectedText);
+          setSelectedText(res.selectedText);
+          clearSelection();
+          setMenuVisible("hidden");
+        },
+      })
+      .exec();
+  };
+
+  return (
+    <view className="plain-surface selection-area">
+      <markdown
+        id="markdown"
+        content={content}
+        text-selection={true}
+        bindselectionchange={onSelectionChange}
+        style="overflow:visible;"
+      />
+      <view
+        id="menu"
+        className="selection-menu"
+        style={{
+          visibility: menuVisible,
+          left: leftOffset + "px",
+          top: topOffset + "px",
+          width: "60px",
+        }}
+      >
+        <view className="menu-inner">
+          <text className="menu-button">Select</text>
+          <view className="menu-divider" />
+          <text className="menu-button" bindtap={onCopy}>Copy</text>
+        </view>
+      </view>
+      {selectedText ? <text className="copied-text">Copied: {selectedText}</text> : null}
+    </view>
+  );
+}
+
+renderExample("Selection Copy", <App />);

--- a/examples/markdown/src/selection_menu/index.tsx
+++ b/examples/markdown/src/selection_menu/index.tsx
@@ -1,0 +1,89 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { useState } from "@lynx-js/react";
+
+import type * as Lynx from "@lynx-js/types";
+import { renderExample } from "../common.js";
+import type { MarkdownTextBoundingRect } from "../intrinsic-element.js";
+
+function App() {
+  const content = `
+this is a **Markdown**!!
+
+this is a **Markdown**!!
+
+this is a **Markdown**!!
+  `;
+  const [menuVisible, setMenuVisible] = useState<"hidden" | "visible">(
+    "hidden",
+  );
+  const [topOffset, setTopOffset] = useState(0);
+  const [leftOffset, setLeftOffset] = useState(0);
+
+  const onSelectionChange = (
+    params: Lynx.BaseEvent<
+      "bindselectionchange",
+      { start: number; end: number }
+    >,
+  ) => {
+    const start = params.detail.start;
+    const end = params.detail.end;
+    console.log("selection change: " + start + "," + end);
+    if (start === -1) {
+      setMenuVisible("hidden");
+    } else {
+      setMenuVisible("visible");
+      lynx
+        .createSelectorQuery()
+        .select("#markdown")
+        .invoke({
+          method: "getTextBoundingRect",
+          params: {
+            start,
+            end,
+          },
+          success(res: MarkdownTextBoundingRect) {
+            console.log(res.boundingRect);
+            setLeftOffset(res.boundingRect.left + res.boundingRect.width / 2 - 30);
+            setTopOffset(res.boundingRect.top + res.boundingRect.height / 2 - 10);
+          },
+          fail(res) {
+            console.log(res.code, res.data);
+          },
+        })
+        .exec();
+    }
+  };
+
+  return (
+    <view className="plain-surface selection-area">
+      <markdown
+        id="markdown"
+        content={content}
+        text-selection={true}
+        bindselectionchange={onSelectionChange}
+        style="overflow:visible;"
+      />
+      <view
+        id="menu"
+        className="selection-menu"
+        style={{
+          visibility: menuVisible,
+          left: leftOffset + "px",
+          top: topOffset + "px",
+          width: "60px",
+        }}
+      >
+        <view className="menu-inner">
+          <text className="menu-button">Select</text>
+          <view className="menu-divider" />
+          <text className="menu-button">Copy</text>
+        </view>
+      </view>
+    </view>
+  );
+}
+
+renderExample("Selection Menu", <App />);

--- a/examples/markdown/src/selection_paragraph/index.tsx
+++ b/examples/markdown/src/selection_paragraph/index.tsx
@@ -1,0 +1,113 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { useRef, useState } from "@lynx-js/react";
+
+import type * as Lynx from "@lynx-js/types";
+import { renderExample } from "../common.js";
+import type { MarkdownTextBoundingRect } from "../intrinsic-element.js";
+
+function App() {
+  const content = `
+this is a **Markdown**!!
+
+this is a **Markdown**!!
+
+this is a **Markdown**!!
+  `;
+  const inSelection = useRef(false);
+  const [menuVisible, setMenuVisible] = useState<"hidden" | "visible">(
+    "hidden",
+  );
+  const [topOffset, setTopOffset] = useState(0);
+  const [leftOffset, setLeftOffset] = useState(0);
+
+  const onSelectionChange = (
+    params: Lynx.BaseEvent<
+      "bindselectionchange",
+      { start: number; end: number }
+    >,
+  ) => {
+    const start = params.detail.start;
+    const end = params.detail.end;
+    console.log("selection change: " + start + "," + end);
+    if (start === -1) {
+      setMenuVisible("hidden");
+      inSelection.current = false;
+      return;
+    }
+
+    const modifySelection = !inSelection.current;
+    setMenuVisible("visible");
+    lynx
+      .createSelectorQuery()
+      .select("#markdown")
+      .invoke({
+        method: "getTextBoundingRect",
+        params: {
+          start,
+          end,
+        },
+        success(res: MarkdownTextBoundingRect) {
+          console.log(res.boundingRect);
+          if (modifySelection) {
+            const x = res.boundingRect.left + res.boundingRect.width / 2;
+            const y = res.boundingRect.top + res.boundingRect.height / 2;
+            lynx
+              .createSelectorQuery()
+              .select("#markdown")
+              .invoke({
+                method: "setTextSelection",
+                params: {
+                  startX: x,
+                  startY: y,
+                  endX: x,
+                  endY: y,
+                  selectionTextType: "paragraph",
+                },
+              })
+              .exec();
+          } else {
+            setLeftOffset(res.boundingRect.left + res.boundingRect.width / 2 - 30);
+            setTopOffset(res.boundingRect.top + res.boundingRect.height / 2 - 10);
+          }
+        },
+        fail(res) {
+          console.log(res.code, res.data);
+        },
+      })
+      .exec();
+    inSelection.current = true;
+  };
+
+  return (
+    <view className="plain-surface selection-area">
+      <markdown
+        id="markdown"
+        content={content}
+        text-selection={true}
+        bindselectionchange={onSelectionChange}
+        style="overflow:visible;"
+      />
+      <view
+        id="menu"
+        className="selection-menu"
+        style={{
+          visibility: menuVisible,
+          left: leftOffset + "px",
+          top: topOffset + "px",
+          width: "60px",
+        }}
+      >
+        <view className="menu-inner">
+          <text className="menu-button">Select</text>
+          <view className="menu-divider" />
+          <text className="menu-button">Copy</text>
+        </view>
+      </view>
+    </view>
+  );
+}
+
+renderExample("Selection Paragraph", <App />);

--- a/examples/markdown/src/selection_select_all/index.tsx
+++ b/examples/markdown/src/selection_select_all/index.tsx
@@ -1,0 +1,101 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { useState } from "@lynx-js/react";
+
+import type * as Lynx from "@lynx-js/types";
+import { renderExample } from "../common.js";
+import type { MarkdownTextBoundingRect } from "../intrinsic-element.js";
+
+function App() {
+  const content = `
+this is a **Markdown**!!
+
+this is a **Markdown**!!
+
+this is a **Markdown**!!
+  `;
+  const [menuVisible, setMenuVisible] = useState<"hidden" | "visible">(
+    "hidden",
+  );
+  const [topOffset, setTopOffset] = useState(0);
+  const [leftOffset, setLeftOffset] = useState(0);
+
+  const onSelectionChange = (
+    params: Lynx.BaseEvent<
+      "bindselectionchange",
+      { start: number; end: number }
+    >,
+  ) => {
+    const start = params.detail.start;
+    const end = params.detail.end;
+    if (start === -1) {
+      setMenuVisible("hidden");
+      return;
+    }
+
+    setMenuVisible("visible");
+    lynx
+      .createSelectorQuery()
+      .select("#markdown")
+      .invoke({
+        method: "getTextBoundingRect",
+        params: {
+          start,
+          end,
+        },
+        success(res: MarkdownTextBoundingRect) {
+          setLeftOffset(res.boundingRect.left + res.boundingRect.width / 2 - 30);
+          setTopOffset(res.boundingRect.top + res.boundingRect.height / 2 - 10);
+        },
+      })
+      .exec();
+  };
+
+  const onSelectAll = () => {
+    lynx
+      .createSelectorQuery()
+      .select("#markdown")
+      .invoke({
+        method: "setTextSelection",
+        params: {
+          startX: 0,
+          startY: 0,
+          endX: Number.MAX_VALUE,
+          endY: Number.MAX_VALUE,
+        },
+      })
+      .exec();
+  };
+
+  return (
+    <view className="plain-surface selection-area">
+      <markdown
+        id="markdown"
+        content={content}
+        text-selection={true}
+        bindselectionchange={onSelectionChange}
+        style="overflow:visible;"
+      />
+      <view
+        id="menu"
+        className="selection-menu"
+        style={{
+          visibility: menuVisible,
+          left: leftOffset + "px",
+          top: topOffset + "px",
+          width: "60px",
+        }}
+      >
+        <view className="menu-inner">
+          <text className="menu-button" bindtap={onSelectAll}>Select</text>
+          <view className="menu-divider" />
+          <text className="menu-button">Copy</text>
+        </view>
+      </view>
+    </view>
+  );
+}
+
+renderExample("Selection Select All", <App />);

--- a/examples/markdown/src/span_mark/index.tsx
+++ b/examples/markdown/src/span_mark/index.tsx
@@ -1,0 +1,34 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+import type { MarkdownStyle } from "../intrinsic-element.js";
+
+function App() {
+  const content = `
+<span class="hl">highlighted text</span>, <span class="uline">underlined text</span>.
+`;
+  const style: MarkdownStyle = {
+    ".hl": {
+      backgroundImage:
+        "linear-gradient(180deg, rgba(255, 245, 157, 0) 0%, rgba(255, 245, 157, 0) 60%, rgba(255, 245, 157, 1) 60%, rgba(255, 245, 157, 1) 100%)",
+      paddingLeft: 2,
+      paddingRight: 2,
+    },
+    ".uline": {
+      textDecorationLine: "underline",
+      textDecorationColor: "ff9800",
+      textDecorationStyle: "solid",
+      textDecorationThickness: 2,
+    },
+  };
+
+  return (
+    <view className="plain-surface">
+      <markdown content={content} markdown-style={style} />
+    </view>
+  );
+}
+
+renderExample("Span Mark", <App />);

--- a/examples/markdown/src/span_style/index.tsx
+++ b/examples/markdown/src/span_style/index.tsx
@@ -1,0 +1,30 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+import type { MarkdownStyle } from "../intrinsic-element.js";
+
+function App() {
+  const content = `
+this is [<span class="red">link1</span>](url1).
+
+this is [link2](url1).
+`;
+  const style: MarkdownStyle = {
+    ".red": {
+      color: "ff0000",
+    },
+    link: {
+      color: "0000ff",
+    },
+  };
+
+  return (
+    <view className="plain-surface">
+      <markdown content={content} markdown-style={style} />
+    </view>
+  );
+}
+
+renderExample("Span Style", <App />);

--- a/examples/markdown/src/style/index.tsx
+++ b/examples/markdown/src/style/index.tsx
@@ -1,0 +1,31 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+import type { MarkdownStyle } from "../intrinsic-element.js";
+
+function App() {
+  const content = `
+this is a **Markdown**!!
+
+this is a \`inline code\`.
+`;
+  const style: MarkdownStyle = {
+    normalText: {
+      fontSize: 25,
+    },
+    inlineCode: {
+      fontSize: 20,
+      color: "ff0000",
+    },
+  };
+
+  return (
+    <view className="plain-surface">
+      <markdown content={content} markdown-style={style} />
+    </view>
+  );
+}
+
+renderExample("Style", <App />);

--- a/examples/markdown/src/text_mark_attachments/index.tsx
+++ b/examples/markdown/src/text_mark_attachments/index.tsx
@@ -1,0 +1,44 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+import type { MarkdownMarkAttachment } from "../intrinsic-element.js";
+
+function App() {
+  const content = `
+highlighted text, overlapping text, underlined text.
+`;
+  const attachments: MarkdownMarkAttachment[] = [
+    {
+      startIndex: 0,
+      endIndex: 35,
+      indexType: "source",
+      style: {
+        color:
+          "linear-gradient(180deg, rgba(255, 245, 157, 0) 0%, rgba(255, 245, 157, 0) 60%, rgba(255, 245, 157, 1) 60%, rgba(255, 245, 157, 1) 100%)",
+      },
+    },
+    {
+      startIndex: 18,
+      endIndex: 53,
+      indexType: "source",
+      style: {
+        borderBottom: {
+          lineType: "dashed",
+          width: "2px",
+          color:
+            "linear-gradient(90deg,rgba(42, 123, 155, 1) 0%, rgba(87, 199, 133, 1) 50%, rgba(237, 221, 83, 1) 100%)",
+        },
+      },
+    },
+  ];
+
+  return (
+    <view className="plain-surface">
+      <markdown content={content} text-mark-attachments={attachments} />
+    </view>
+  );
+}
+
+renderExample("Text Mark Attachments", <App />);

--- a/examples/markdown/src/text_selection/index.tsx
+++ b/examples/markdown/src/text_selection/index.tsx
@@ -1,0 +1,19 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+
+function App() {
+  const content = `
+this is a **Markdown**!!
+`;
+
+  return (
+    <view className="plain-surface">
+      <markdown content={content} text-selection={true} />
+    </view>
+  );
+}
+
+renderExample("Text Selection", <App />);

--- a/examples/markdown/src/truncation/index.tsx
+++ b/examples/markdown/src/truncation/index.tsx
@@ -1,0 +1,28 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+
+function App() {
+  const content = `
+this is a **Markdown**!!
+
+this is a **Markdown**!!
+
+this is a **Markdown**!!
+  `;
+
+  return (
+    <view className="plain-surface" style="height:100vh;position:relative;">
+      <markdown
+        id="markdown"
+        content={content}
+        text-maxline={2}
+        style={{ height: "100px" }}
+      />
+    </view>
+  );
+}
+
+renderExample("Truncation", <App />);

--- a/examples/markdown/src/truncation_text/index.tsx
+++ b/examples/markdown/src/truncation_text/index.tsx
@@ -1,0 +1,35 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+import type { MarkdownStyle } from "../intrinsic-element.js";
+
+function App() {
+  const content = `
+this is a **Markdown**!!
+
+this is a **Markdown**!!
+
+this is a **Markdown**!!
+  `;
+  const style: MarkdownStyle = {
+    truncation: {
+      content: "...more",
+    },
+  };
+
+  return (
+    <view className="plain-surface" style="height:100vh;position:relative;">
+      <markdown
+        id="markdown"
+        content={content}
+        markdown-style={style}
+        text-maxline={2}
+        style="height:100px;"
+      />
+    </view>
+  );
+}
+
+renderExample("Truncation Text", <App />);

--- a/examples/markdown/src/truncation_view/index.tsx
+++ b/examples/markdown/src/truncation_view/index.tsx
@@ -1,0 +1,40 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+import type { MarkdownStyle } from "../intrinsic-element.js";
+
+function App() {
+  const content = `
+this is a **Markdown**!!
+
+this is a **Markdown**!!
+
+this is a **Markdown**!!
+  `;
+  const style: MarkdownStyle = {
+    truncation: {
+      content: "truncation",
+      truncationType: "view",
+    },
+  };
+
+  return (
+    <view className="plain-surface" style="height:100vh;position:relative;">
+      <markdown
+        id="markdown"
+        content={content}
+        markdown-style={style}
+        text-maxline={2}
+        style="height:100px;"
+      >
+        <view id="truncation" className="truncation-view">
+          <text className="truncation-text">...expand</text>
+        </view>
+      </markdown>
+    </view>
+  );
+}
+
+renderExample("Truncation View", <App />);

--- a/examples/markdown/src/typewriter/index.tsx
+++ b/examples/markdown/src/typewriter/index.tsx
@@ -1,0 +1,23 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+
+function App() {
+  const content = `
+this is a **Markdown**!!
+`;
+
+  return (
+    <view className="plain-surface">
+      <markdown
+        content={content}
+        animation-type="typewriter"
+        animation-velocity={20}
+      />
+    </view>
+  );
+}
+
+renderExample("Typewriter", <App />);

--- a/examples/markdown/src/typewriter_cursor/index.tsx
+++ b/examples/markdown/src/typewriter_cursor/index.tsx
@@ -1,0 +1,32 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+import type { MarkdownStyle } from "../intrinsic-element.js";
+
+function App() {
+  const content = `
+this is a **Markdown**!!
+`;
+  const style: MarkdownStyle = {
+    typewriterCursor: {
+      customCursor: "cursor",
+    },
+  };
+
+  return (
+    <view className="plain-surface">
+      <markdown
+        content={content}
+        markdown-style={style}
+        animation-type="typewriter"
+        animation-velocity={20}
+      >
+        <view id="cursor" className="cursor"></view>
+      </markdown>
+    </view>
+  );
+}
+
+renderExample("Typewriter Cursor", <App />);

--- a/examples/markdown/src/typewriter_keep_cursor/index.tsx
+++ b/examples/markdown/src/typewriter_keep_cursor/index.tsx
@@ -1,0 +1,33 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { renderExample } from "../common.js";
+import type { MarkdownStyle } from "../intrinsic-element.js";
+
+function App() {
+  const content = `
+this is a **Markdown**!!
+`;
+  const style: MarkdownStyle = {
+    typewriterCursor: {
+      customCursor: "cursor",
+    },
+  };
+
+  return (
+    <view className="plain-surface">
+      <markdown
+        content={content}
+        markdown-style={style}
+        animation-type="typewriter"
+        animation-velocity={20}
+        content-complete={false}
+      >
+        <view id="cursor" className="cursor"></view>
+      </markdown>
+    </view>
+  );
+}
+
+renderExample("Typewriter Keep Cursor", <App />);

--- a/examples/markdown/src/typewriter_mask/index.tsx
+++ b/examples/markdown/src/typewriter_mask/index.tsx
@@ -1,0 +1,43 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { useState } from "@lynx-js/react";
+
+import { renderExample } from "../common.js";
+import type { MarkdownEffect, MarkdownStyle } from "../intrinsic-element.js";
+
+function App() {
+  const content = `
+this is a **Markdown**!!
+`;
+  const style: MarkdownStyle = {
+    typewriterCursor: {
+      customCursor: "none",
+    },
+  };
+  const [effect, setEff] = useState<MarkdownEffect>({
+    type: "text-mask",
+    color: "linear-gradient(90deg, #ffffff00 0%, rgb(255, 255, 255) 100%)",
+    rangeStart: -4,
+    rangeEnd: -1,
+  });
+
+  return (
+    <view className="plain-surface">
+      <markdown
+        content={content}
+        markdown-style={style}
+        animation-type="typewriter"
+        animation-velocity={20}
+        markdown-effect={effect}
+        binddrawEnd={() => {
+          setEff({});
+        }}
+      >
+      </markdown>
+    </view>
+  );
+}
+
+renderExample("Typewriter Mask", <App />);

--- a/examples/markdown/tsconfig.json
+++ b/examples/markdown/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "@lynx-js/react",
+
+    "module": "node16",
+    "moduleResolution": "node16",
+
+    "strict": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+
+    "paths": {
+    },
+  },
+  "exclude": ["dist/"],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -884,6 +884,31 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
 
+  examples/markdown:
+    dependencies:
+      '@lynx-js/react':
+        specifier: 'catalog:'
+        version: 0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.28)
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.4.7
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.16.3(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.28))(tslib@2.8.1)(webpack@5.101.3)
+      '@lynx-js/rspeedy':
+        specifier: 'catalog:'
+        version: 0.14.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(typescript@5.9.3)(webpack@5.101.3)
+      '@lynx-js/types':
+        specifier: 3.9.0
+        version: 3.9.0
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+
   examples/motion:
     dependencies:
       '@lynx-js/luna-styles':


### PR DESCRIPTION
## Summary

Add a new `@lynx-example/markdown` example package with standalone entries for Markdown snippets covering styles, inline views, images, text marks, truncation, typewriter animation, and text selection.

The package includes a changeset and lockfile importer entry so release metadata and workspace installs stay in sync.

## Validation

- `pnpm meta-updater --test`
- `pnpm --filter @lynx-example/markdown run build`
- `pnpm dprint check`
