### PR TITLE
ci: publish PR previews to pkg.pr.new

### DIFF
--- a/.github/scripts/list-changeset-packages.cjs
+++ b/.github/scripts/list-changeset-packages.cjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+// Print the directories of publishable workspace packages that appear in the
+// `releases` array of a `changeset status --output` JSON file. One path per
+// line, relative to the repository root. Used by the pkg.pr.new workflow to
+// publish only packages touched by a PR's changesets.
+const { execSync } = require("node:child_process");
+const { readFileSync } = require("node:fs");
+
+function main() {
+  const statusFile = process.argv[2] || ".changeset-status.json";
+  const raw = readFileSync(statusFile, "utf8");
+  const data = JSON.parse(raw);
+  const releases = Array.isArray(data.releases) ? data.releases : [];
+  // `releases` includes packages reached via the dependency graph with
+  // `type: "none"` — those don't actually get a version bump, so skip them.
+  const affected = new Set(
+    releases
+      .filter((r) => r?.type && r.type !== "none")
+      .map((r) => r.name)
+      .filter(Boolean),
+  );
+
+  if (affected.size === 0) {
+    return;
+  }
+
+  const workspace = JSON.parse(
+    execSync("pnpm m ls --json --depth=-1", { encoding: "utf8" }),
+  );
+
+  for (const pkg of workspace) {
+    if (!pkg.name || pkg.private) continue;
+    if (!affected.has(pkg.name)) continue;
+    process.stdout.write(`${pkg.path}\n`);
+  }
+}
+
+main();

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,34 @@ jobs:
           TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
           NODE_OPTIONS: --max-old-space-size=8192
         run: pnpm turbo run build --affected --concurrency=4
+      # Publish PR previews to pkg.pr.new, but only when the PR adds a
+      # changeset that actually bumps a publishable package. Fork PRs are
+      # included: this is a `pull_request` (not `pull_request_target`)
+      # workflow, so fork runs use a read-only token with no base-repo secrets
+      # — the same trust boundary the Build step above (which already runs fork
+      # build scripts) relies on.
+      - name: Collect packages with changesets
+        id: changeset
+        env:
+          CHANGESET_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          pnpm changeset status --since "$CHANGESET_BASE_SHA" --output .changeset-status.json
+          PACKAGE_DIRS=$(node .github/scripts/list-changeset-packages.cjs .changeset-status.json | tr '\n' ' ')
+          if [ -z "$(echo "$PACKAGE_DIRS" | tr -d '[:space:]')" ]; then
+            echo "No publishable packages affected by changesets; skipping pkg.pr.new publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Publishing the following package directories to pkg.pr.new:"
+          printf '  %s\n' $PACKAGE_DIRS
+          {
+            echo "skip=false"
+            echo "package-dirs<<EOF"
+            echo "$PACKAGE_DIRS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Publish to pkg.pr.new
+        if: steps.changeset.outputs.skip == 'false'
+        env:
+          PACKAGE_DIRS: ${{ steps.changeset.outputs.package-dirs }}
+        run: pnpm dlx pkg-pr-new publish --compact --pnpm $PACKAGE_DIRS


### PR DESCRIPTION
## What

Adds [pkg.pr.new](https://pkg.pr.new) preview publishing to PR CI, adapted from the lynx-stack reference workflow.

On every PR, after the build, CI detects which **publishable** packages the PR's changesets bump and publishes just those to pkg.pr.new — giving reviewers installable preview packages tied to the PR.

## Changes

- **`.github/scripts/list-changeset-packages.cjs`** (new): maps `changeset status` releases to publishable workspace package directories (skips `type: "none"` graph entries and private packages).
- **`.github/workflows/ci.yml`**: two new steps on the `test` job —
  - *Collect packages with changesets* — runs `changeset status --since <base-sha>` and resolves package dirs (sets `skip=true` when none).
  - *Publish to pkg.pr.new* — runs `pnpm dlx pkg-pr-new publish --compact --pnpm $PACKAGE_DIRS`, gated on there being affected packages.

## Notes vs. reference

- This repo already checks out with `fetch-depth: 0`, so the reference's merge-base deepening step is unnecessary — reused `github.event.pull_request.base.sha` like the existing Lint step.
- Single-platform job, so dropped the matrix-leg guard.

## ⚠️ Requires

The [pkg.pr.new GitHub App](https://github.com/apps/pkg-pr-new) must be installed on this repo (it authenticates via the App, no secret needed). The publish step fails until that's done.

## Verified

Script locally resolves the existing `@lynx-example/markdown` changeset → `examples/markdown`; `ci.yml` parses as valid YAML.