### PR TITLE
chore(video): add public publish config

### DIFF
--- a/examples/video/package.json
+++ b/examples/video/package.json
@@ -32,5 +32,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary
- Add public publishConfig access metadata for @lynx-example/video.

## Tests
- pnpm meta-updater --test
- pnpm dprint check examples/video/package.json
- pnpm changeset status --verbose --since origin/main