### PR TITLE
feat: add lynx-ui-gallery and react-devtool examples

### DIFF
--- a/.changeset/lynx-ui-gallery-and-react-devtool.md
+++ b/.changeset/lynx-ui-gallery-and-react-devtool.md
@@ -1,0 +1,6 @@
+---
+"@lynx-example/lynx-ui-gallery": minor
+"@lynx-example/react-devtool": minor
+---
+
+Add lynx-ui-gallery kitchen sink example covering all lynx-ui components, and react-devtool example with preact-devtools support via REACT_DEV env var.

--- a/examples/lynx-ui-gallery/lynx.config.ts
+++ b/examples/lynx-ui-gallery/lynx.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "@lynx-js/rspeedy";
+
+import { pluginQRCode } from "@lynx-js/qrcode-rsbuild-plugin";
+import { pluginReactLynx } from "@lynx-js/react-rsbuild-plugin";
+
+export default defineConfig({
+  plugins: [
+    pluginQRCode(),
+    pluginReactLynx({
+      enableNewGesture: true,
+    }),
+  ],
+  output: {
+    filename: "[name].[platform].bundle",
+  },
+  environments: {
+    web: {},
+    lynx: {},
+  },
+});

--- a/examples/lynx-ui-gallery/lynx.config.ts
+++ b/examples/lynx-ui-gallery/lynx.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "@lynx-js/rspeedy";
 
+import { pluginLynxConfig } from "@lynx-js/config-rsbuild-plugin";
 import { pluginQRCode } from "@lynx-js/qrcode-rsbuild-plugin";
 import { pluginReactLynx } from "@lynx-js/react-rsbuild-plugin";
 
@@ -8,6 +9,9 @@ export default defineConfig({
     pluginQRCode(),
     pluginReactLynx({
       enableNewGesture: true,
+    }),
+    pluginLynxConfig({
+      enableCSSInlineVariables: true,
     }),
   ],
   output: {

--- a/examples/lynx-ui-gallery/package.json
+++ b/examples/lynx-ui-gallery/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@lynx-example/lynx-ui-gallery",
+  "version": "0.1.0",
+  "description": "A Kitchen Sink gallery showcasing all lynx-ui components",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lynx-family/lynx-examples.git",
+    "directory": "examples/lynx-ui-gallery"
+  },
+  "author": "Lynx Authors",
+  "type": "module",
+  "files": [
+    "dist/",
+    "src/",
+    "lynx.config.ts"
+  ],
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev",
+    "preview": "rspeedy preview"
+  },
+  "dependencies": {
+    "@lynx-js/lynx-ui": "3.133.1",
+    "@lynx-js/preact-devtools": "5.0.1-20260525112551-dfe2d03",
+    "@lynx-js/react": "catalog:"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
+    "@lynx-js/react-rsbuild-plugin": "catalog:",
+    "@lynx-js/rspeedy": "catalog:",
+    "@lynx-js/types": "catalog:",
+    "@types/react": "^18.3.28",
+    "typescript": "~5.9.3"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/examples/lynx-ui-gallery/package.json
+++ b/examples/lynx-ui-gallery/package.json
@@ -20,11 +20,13 @@
     "preview": "rspeedy preview"
   },
   "dependencies": {
+    "@lynx-js/luna-styles": "0.1.0",
     "@lynx-js/lynx-ui": "3.133.1",
     "@lynx-js/preact-devtools": "5.0.1-20260525112551-dfe2d03",
     "@lynx-js/react": "catalog:"
   },
   "devDependencies": {
+    "@lynx-js/config-rsbuild-plugin": "catalog:",
     "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
     "@lynx-js/react-rsbuild-plugin": "catalog:",
     "@lynx-js/rspeedy": "catalog:",

--- a/examples/lynx-ui-gallery/src/App.css
+++ b/examples/lynx-ui-gallery/src/App.css
@@ -1,0 +1,612 @@
+.gallery-container {
+  width: 100%;
+  height: 100%;
+  background-color: #1a1a2e;
+}
+
+.gallery-scroll {
+  width: 100%;
+  height: 100%;
+}
+
+.gallery-header {
+  padding: 48px 24px 24px;
+  align-items: center;
+}
+
+.gallery-title {
+  font-size: 28px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.gallery-subtitle {
+  font-size: 14px;
+  color: #888;
+  margin-top: 4px;
+}
+
+.gallery-footer {
+  padding: 32px 24px;
+  align-items: center;
+}
+
+.gallery-footer-text {
+  font-size: 14px;
+  color: #666;
+}
+
+.section {
+  margin: 12px 16px;
+  padding: 16px;
+  background-color: #16213e;
+  border-radius: 12px;
+}
+
+.section-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #e94560;
+  margin-bottom: 12px;
+}
+
+.section-content {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.subsection-title {
+  font-size: 14px;
+  font-weight: 500;
+  color: #aaa;
+  margin-top: 8px;
+}
+
+.row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+}
+
+.row-indent {
+  padding-left: 24px;
+}
+
+.row-label {
+  font-size: 14px;
+  color: #ccc;
+}
+
+.row-label-disabled {
+  opacity: 0.4;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field-label {
+  font-size: 13px;
+  color: #aaa;
+}
+
+/* Button */
+.gallery-button {
+  align-self: flex-start;
+}
+
+.btn {
+  padding: 10px 20px;
+  background-color: #e94560;
+  border-radius: 8px;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn-active {
+  background-color: #c0392b;
+}
+
+.btn-disabled {
+  background-color: #555;
+  opacity: 0.6;
+}
+
+.btn-text {
+  font-size: 14px;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+/* Switch */
+.switch {
+  width: 48px;
+  height: 28px;
+}
+
+.switch-track {
+  width: 48px;
+  height: 28px;
+  border-radius: 14px;
+  background-color: #444;
+}
+
+.switch-track.ui-checked {
+  background-color: #e94560;
+}
+
+.switch-thumb {
+  width: 24px;
+  height: 24px;
+  border-radius: 12px;
+  background-color: #fff;
+  margin: 2px;
+}
+
+/* Checkbox */
+.checkbox {
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
+  border: 2px solid #666;
+  align-items: center;
+  justify-content: center;
+}
+
+.checkbox.ui-checked {
+  background-color: #e94560;
+  border-color: #e94560;
+}
+
+.checkbox-indicator {
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+}
+
+.checkmark {
+  width: 12px;
+  height: 12px;
+  background-color: #fff;
+  border-radius: 2px;
+}
+
+.indeterminate-mark {
+  width: 12px;
+  height: 3px;
+  background-color: #fff;
+  border-radius: 1px;
+}
+
+/* Radio */
+.radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.radio-item {
+  width: 22px;
+  height: 22px;
+  border-radius: 11px;
+  border: 2px solid #666;
+  align-items: center;
+  justify-content: center;
+}
+
+.radio-item.ui-checked {
+  border-color: #e94560;
+}
+
+.radio-indicator {
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+}
+
+.radio-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 6px;
+  background-color: #e94560;
+}
+
+/* Slider */
+.slider-root {
+  width: 100%;
+  height: 40px;
+}
+
+.slider-track {
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background-color: #333;
+}
+
+.slider-indicator {
+  height: 6px;
+  border-radius: 3px;
+  background-color: #e94560;
+}
+
+.slider-thumb-wrapper {
+  width: 24px;
+  height: 24px;
+  align-items: center;
+  justify-content: center;
+}
+
+.slider-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 10px;
+  background-color: #fff;
+  border: 2px solid #e94560;
+}
+
+/* Input */
+.input {
+  height: 40px;
+  padding: 0 12px;
+  background-color: #0f3460;
+  border-radius: 8px;
+  border: 1px solid #333;
+  color: #fff;
+  font-size: 14px;
+}
+
+.textarea-wrap {
+  height: 80px;
+}
+
+.textarea {
+  width: 100%;
+  height: 100%;
+  padding: 10px 12px;
+  background-color: #0f3460;
+  border-radius: 8px;
+  border: 1px solid #333;
+  color: #fff;
+  font-size: 14px;
+}
+
+/* Dialog */
+.dialog-trigger {
+  padding: 10px 20px;
+  background-color: #e94560;
+  border-radius: 8px;
+  align-self: flex-start;
+}
+
+.dialog-viewport {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  align-items: center;
+  justify-content: center;
+}
+
+.dialog-backdrop {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.6);
+}
+
+.dialog-content {
+  width: 300px;
+  background-color: #16213e;
+  border-radius: 16px;
+  padding: 24px;
+  align-items: center;
+}
+
+.dialog-body {
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.dialog-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #fff;
+  margin-bottom: 8px;
+}
+
+.dialog-desc {
+  font-size: 14px;
+  color: #aaa;
+  text-align: center;
+}
+
+.dialog-close-btn {
+  padding: 10px 24px;
+  background-color: #e94560;
+  border-radius: 8px;
+}
+
+/* Sheet */
+.sheet-viewport {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.sheet-backdrop {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.sheet-content {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: #16213e;
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+}
+
+.sheet-inner-content {
+  padding: 16px;
+}
+
+.sheet-handle {
+  width: 40px;
+  height: 4px;
+  background-color: #666;
+  border-radius: 2px;
+  align-self: center;
+  margin-top: 8px;
+  margin-bottom: 16px;
+}
+
+.sheet-body {
+  padding: 8px;
+  align-items: center;
+  gap: 12px;
+}
+
+/* Popover */
+.popover-trigger {
+  align-self: flex-start;
+}
+
+.popover-positioner {
+  margin-top: 4px;
+}
+
+.popover-content {
+  background-color: #0f3460;
+  border-radius: 8px;
+  padding: 12px 16px;
+  border: 1px solid #333;
+}
+
+.popover-body {
+  max-width: 200px;
+}
+
+.popover-text {
+  font-size: 13px;
+  color: #ccc;
+}
+
+/* Swiper */
+.swiper-card {
+  width: 100%;
+  height: 150px;
+  border-radius: 12px;
+  align-items: center;
+  justify-content: center;
+}
+
+.swiper-card-text {
+  font-size: 20px;
+  font-weight: 700;
+  color: #fff;
+}
+
+/* ScrollView */
+.gallery-scroll-view {
+  height: 80px;
+}
+
+.scroll-content-h {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  padding: 8px 0;
+}
+
+.scroll-item {
+  width: 56px;
+  height: 56px;
+  border-radius: 28px;
+  background-color: #0f3460;
+  align-items: center;
+  justify-content: center;
+}
+
+.scroll-item-text {
+  font-size: 18px;
+  font-weight: 600;
+  color: #e94560;
+}
+
+/* SwipeAction */
+.swipe-container {
+  height: 60px;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.swipe-action {
+  height: 60px;
+}
+
+.swipe-display {
+  height: 60px;
+  background-color: #0f3460;
+  padding: 0 16px;
+  justify-content: center;
+}
+
+.swipe-display-text {
+  font-size: 14px;
+  color: #ccc;
+}
+
+.swipe-action-area {
+  width: 80px;
+  height: 60px;
+  background-color: #e94560;
+  align-items: center;
+  justify-content: center;
+}
+
+.swipe-action-text {
+  font-size: 14px;
+  font-weight: 600;
+  color: #fff;
+}
+
+/* Draggable */
+.draggable-area {
+  height: 160px;
+  background-color: #0f3460;
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: row;
+  gap: 16px;
+}
+
+.draggable-item {
+  align-self: flex-start;
+}
+
+.draggable-box {
+  width: 100px;
+  height: 100px;
+  background-color: #e94560;
+  border-radius: 12px;
+  align-items: center;
+  justify-content: center;
+}
+
+.draggable-box-alt {
+  background-color: #4ecdc4;
+}
+
+.draggable-text {
+  font-size: 12px;
+  font-weight: 600;
+  color: #fff;
+  text-align: center;
+}
+
+/* Sortable */
+.sortable-boundary {
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.sortable-item {
+  height: 48px;
+  background-color: #0f3460;
+  border-bottom: 1px solid #1a1a2e;
+}
+
+.sortable-item-area {
+  height: 48px;
+  padding: 0 16px;
+  justify-content: center;
+}
+
+.sortable-item-text {
+  font-size: 14px;
+  color: #ccc;
+}
+
+/* List */
+.gallery-list {
+  height: 200px;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.list-item {
+  height: 44px;
+  padding: 0 16px;
+  background-color: #0f3460;
+  border-bottom: 1px solid #1a1a2e;
+  justify-content: center;
+}
+
+.list-item-text {
+  font-size: 14px;
+  color: #ccc;
+}
+
+/* FeedList */
+.feed-list {
+  height: 220px;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.feed-item {
+  height: 52px;
+  padding: 0 16px;
+  background-color: #0f3460;
+  border-bottom: 1px solid #1a1a2e;
+  justify-content: center;
+}
+
+.feed-item-text {
+  font-size: 14px;
+  color: #ccc;
+}
+
+.feed-footer {
+  height: 44px;
+  align-items: center;
+  justify-content: center;
+}
+
+.feed-footer-text {
+  font-size: 13px;
+  color: #888;
+}
+
+/* LazyComponent */
+.lazy-content {
+  height: 80px;
+  background-color: #0f3460;
+  border-radius: 8px;
+  align-items: center;
+  justify-content: center;
+}
+
+.lazy-text {
+  font-size: 14px;
+  color: #4ecdc4;
+}

--- a/examples/lynx-ui-gallery/src/App.css
+++ b/examples/lynx-ui-gallery/src/App.css
@@ -254,26 +254,36 @@
 
 /* Slider */
 .slider-root {
+  position: relative;
   width: 100%;
-  height: 40px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+}
+
+.slider-root.ui-disabled {
+  opacity: 0.4;
 }
 
 .slider-track {
   width: 100%;
-  height: 6px;
-  border-radius: 3px;
-  background-color: #333;
+  height: 4px;
+  border-radius: 9999px;
+  background-color: var(--neutral-faint, #333);
 }
 
 .slider-indicator {
-  height: 6px;
-  border-radius: 3px;
-  background-color: #e94560;
+  width: 100%;
+  height: 4px;
+  border-radius: 9999px;
+  margin-top: 16px;
+  background: var(--primary, #e94560);
 }
 
 .slider-thumb-wrapper {
-  width: 24px;
-  height: 24px;
+  width: 36px;
+  height: 36px;
+  display: flex;
   align-items: center;
   justify-content: center;
 }
@@ -281,9 +291,9 @@
 .slider-thumb {
   width: 20px;
   height: 20px;
-  border-radius: 10px;
-  background-color: #fff;
-  border: 2px solid #e94560;
+  border-radius: 9999px;
+  background-color: white;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18), 0 3px 8px rgba(0, 0, 0, 0.12);
 }
 
 /* Input */

--- a/examples/lynx-ui-gallery/src/App.css
+++ b/examples/lynx-ui-gallery/src/App.css
@@ -41,6 +41,7 @@
   padding: 16px;
   background-color: #16213e;
   border-radius: 12px;
+  overflow: hidden;
 }
 
 .section-title {
@@ -126,9 +127,15 @@
 .switch {
   width: 48px;
   height: 28px;
+  position: relative;
+  overflow: hidden;
+  border-radius: 14px;
 }
 
 .switch-track {
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 48px;
   height: 28px;
   border-radius: 14px;
@@ -144,7 +151,6 @@
   height: 24px;
   border-radius: 12px;
   background-color: #fff;
-  margin: 2px;
 }
 
 /* Checkbox */

--- a/examples/lynx-ui-gallery/src/App.css
+++ b/examples/lynx-ui-gallery/src/App.css
@@ -1,3 +1,5 @@
+@import "@lynx-js/luna-styles/index.css";
+
 .gallery-container {
   width: 100%;
   height: 100%;
@@ -125,32 +127,59 @@
 
 /* Switch */
 .switch {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
   width: 48px;
   height: 28px;
-  position: relative;
+  border-radius: 9999px;
   overflow: hidden;
-  border-radius: 14px;
+}
+
+.switch.ui-disabled {
+  opacity: 0.5;
 }
 
 .switch-track {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 48px;
-  height: 28px;
-  border-radius: 14px;
-  background-color: #444;
+  width: 100%;
+  height: 100%;
+  background-color: var(--neutral-faint, #444);
+  transition: background-color 150ms ease;
 }
 
 .switch-track.ui-checked {
-  background-color: #e94560;
+  background-color: var(--primary, #e94560);
+}
+
+.switch-track.ui-active {
+  background-color: var(--primary-2, #c0392b);
+}
+
+.switch-track.ui-checked.ui-active {
+  background-color: var(--primary-2, #c0392b);
 }
 
 .switch-thumb {
-  width: 24px;
-  height: 24px;
-  border-radius: 12px;
-  background-color: #fff;
+  position: absolute;
+  width: 22px;
+  height: 22px;
+  transform: translateX(3px);
+  border-radius: 9999px;
+  background-color: var(--primary-content, #fff);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18), 0 3px 8px rgba(0, 0, 0, 0.12);
+  transition: transform 150ms ease, width 150ms ease;
+}
+
+.switch-thumb.ui-checked {
+  transform: translateX(23px);
+}
+
+.switch-thumb.ui-active {
+  width: 33px;
+}
+
+.switch-thumb.ui-checked.ui-active {
+  transform: translateX(12px);
 }
 
 /* Checkbox */

--- a/examples/lynx-ui-gallery/src/App.css
+++ b/examples/lynx-ui-gallery/src/App.css
@@ -3,7 +3,7 @@
 .gallery-container {
   width: 100%;
   height: 100%;
-  background-color: #1a1a2e;
+  background-color: var(--canvas, #1a1a2e);
 }
 
 .gallery-scroll {
@@ -19,12 +19,12 @@
 .gallery-title {
   font-size: 28px;
   font-weight: 700;
-  color: #ffffff;
+  color: var(--content, #fff);
 }
 
 .gallery-subtitle {
   font-size: 14px;
-  color: #888;
+  color: var(--content-muted, #888);
   margin-top: 4px;
 }
 
@@ -35,13 +35,13 @@
 
 .gallery-footer-text {
   font-size: 14px;
-  color: #666;
+  color: var(--content-faint, #666);
 }
 
 .section {
   margin: 12px 16px;
   padding: 16px;
-  background-color: #16213e;
+  background-color: var(--paper, #16213e);
   border-radius: 12px;
   overflow: hidden;
 }
@@ -49,7 +49,7 @@
 .section-title {
   font-size: 18px;
   font-weight: 600;
-  color: #e94560;
+  color: var(--primary, #e94560);
   margin-bottom: 12px;
 }
 
@@ -62,7 +62,7 @@
 .subsection-title {
   font-size: 14px;
   font-weight: 500;
-  color: #aaa;
+  color: var(--content-muted, #aaa);
   margin-top: 8px;
 }
 
@@ -79,7 +79,7 @@
 
 .row-label {
   font-size: 14px;
-  color: #ccc;
+  color: var(--content-2, #ccc);
 }
 
 .row-label-disabled {
@@ -94,38 +94,46 @@
 
 .field-label {
   font-size: 13px;
-  color: #aaa;
+  color: var(--content-muted, #aaa);
 }
 
-/* Button */
+/* =========================
+ * Button
+ * ========================= */
+
 .gallery-button {
   align-self: flex-start;
 }
 
 .btn {
-  padding: 10px 20px;
-  background-color: #e94560;
-  border-radius: 8px;
+  display: flex;
   align-items: center;
   justify-content: center;
+  padding: 10px 20px;
+  background-color: var(--primary, #e94560);
+  border-radius: 9999px;
+  transition: background-color 100ms ease-out;
 }
 
-.btn-active {
-  background-color: #c0392b;
+.btn.ui-active {
+  background-color: var(--primary-2, #c0392b);
 }
 
 .btn-disabled {
-  background-color: #555;
+  background-color: var(--neutral, #555);
   opacity: 0.6;
 }
 
 .btn-text {
   font-size: 14px;
   font-weight: 600;
-  color: #ffffff;
+  color: var(--primary-content, #fff);
 }
 
-/* Switch */
+/* =========================
+ * Switch
+ * ========================= */
+
 .switch {
   display: flex;
   flex-direction: row;
@@ -182,77 +190,120 @@
   transform: translateX(12px);
 }
 
-/* Checkbox */
+/* =========================
+ * Checkbox
+ * ========================= */
+
 .checkbox {
-  width: 22px;
-  height: 22px;
-  border-radius: 4px;
-  border: 2px solid #666;
-  align-items: center;
-  justify-content: center;
+  width: 20px;
+  height: 20px;
 }
 
-.checkbox.ui-checked {
-  background-color: #e94560;
-  border-color: #e94560;
+.checkbox.ui-disabled {
+  opacity: 0.34;
 }
 
 .checkbox-indicator {
   width: 100%;
   height: 100%;
+  display: flex;
   align-items: center;
   justify-content: center;
+  border-radius: 4px;
+  border-width: 1.5px;
+  border-style: solid;
+  border-color: var(--line, #666);
+}
+
+.checkbox-indicator.ui-active {
+  border-color: var(--primary-2);
+  border-width: 1.5px;
+}
+
+.checkbox-indicator.ui-checked {
+  background-color: var(--primary, #e94560);
+  border-width: 0;
+}
+
+.checkbox-indicator.ui-active.ui-checked {
+  background-color: var(--primary-2, #c0392b);
+  border-width: 0;
+}
+
+.checkbox-indicator.ui-indeterminate {
+  background-color: var(--primary, #e94560);
+  border-width: 0;
 }
 
 .checkmark {
-  width: 12px;
-  height: 12px;
-  background-color: #fff;
-  border-radius: 2px;
+  width: 10px;
+  height: 5px;
+  border-left: 2px solid var(--primary-content, #fff);
+  border-bottom: 2px solid var(--primary-content, #fff);
+  transform: rotate(-45deg) translate(1px, -0.5px);
 }
 
 .indeterminate-mark {
-  width: 12px;
-  height: 3px;
-  background-color: #fff;
-  border-radius: 1px;
+  width: 10px;
+  height: 2px;
+  border-radius: 999px;
+  background-color: var(--primary-content, #fff);
 }
 
-/* Radio */
+/* =========================
+ * RadioGroup
+ * ========================= */
+
 .radio-group {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 
 .radio-item {
   width: 22px;
   height: 22px;
-  border-radius: 11px;
-  border: 2px solid #666;
+  border-radius: 9999px;
+  border-width: 1.5px;
+  border-style: solid;
+  border-color: var(--line, #666);
+  display: flex;
   align-items: center;
   justify-content: center;
 }
 
 .radio-item.ui-checked {
-  border-color: #e94560;
+  border-width: 0;
+  background-color: var(--primary, #e94560);
+}
+
+.radio-item.ui-active {
+  border-color: var(--primary-2);
+}
+
+.radio-item.ui-checked.ui-active {
+  background-color: var(--primary-2, #c0392b);
 }
 
 .radio-indicator {
   width: 100%;
   height: 100%;
+  display: flex;
   align-items: center;
   justify-content: center;
 }
 
 .radio-dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 6px;
-  background-color: #e94560;
+  width: 9px;
+  height: 9px;
+  border-radius: 9999px;
+  background-color: var(--primary-content, #fff);
 }
 
-/* Slider */
+/* =========================
+ * Slider
+ * ========================= */
+
 .slider-root {
   position: relative;
   width: 100%;
@@ -296,169 +347,279 @@
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18), 0 3px 8px rgba(0, 0, 0, 0.12);
 }
 
-/* Input */
+/* =========================
+ * Input & TextArea
+ * ========================= */
+
 .input {
-  height: 40px;
-  padding: 0 12px;
-  background-color: #0f3460;
-  border-radius: 8px;
-  border: 1px solid #333;
-  color: #fff;
+  width: 100%;
+  padding: 10px;
+  border-radius: 12px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--line, #333);
+  color: var(--content, #fff);
+  caret-color: var(--primary);
   font-size: 14px;
+}
+
+.input::placeholder {
+  color: var(--content-faint, #666);
+}
+
+.input-container {
+  width: 100%;
 }
 
 .textarea-wrap {
-  height: 80px;
+  width: 100%;
+  padding: 10px;
+  border-radius: 12px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--line, #333);
 }
 
 .textarea {
-  width: 100%;
-  height: 100%;
-  padding: 10px 12px;
-  background-color: #0f3460;
-  border-radius: 8px;
-  border: 1px solid #333;
-  color: #fff;
+  height: 72px;
+  color: var(--content, #fff);
+  caret-color: var(--primary);
   font-size: 14px;
 }
 
-/* Dialog */
+.textarea::placeholder {
+  color: var(--content-faint, #666);
+}
+
+/* =========================
+ * Dialog
+ * ========================= */
+
 .dialog-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 10px 20px;
-  background-color: #e94560;
-  border-radius: 8px;
+  background-color: var(--neutral, #555);
+  border-radius: 9999px;
   align-self: flex-start;
+  transition: background-color 150ms ease;
+}
+
+.dialog-trigger.ui-active {
+  background-color: var(--neutral-2);
 }
 
 .dialog-viewport {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  padding-left: 24px;
+  padding-right: 24px;
+  overflow: hidden;
 }
 
 .dialog-backdrop {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.6);
+  background-color: var(--backdrop, rgba(0, 0, 0, 0.6));
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.dialog-backdrop.ui-open {
+  opacity: 1;
+}
+
+.dialog-backdrop.ui-closed {
+  opacity: 0;
 }
 
 .dialog-content {
-  width: 300px;
-  background-color: #16213e;
-  border-radius: 16px;
-  padding: 24px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
   align-items: center;
+  padding: 24px;
+  border-radius: 24px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--line, #333);
+  background-color: var(--canvas, #16213e);
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.dialog-content.ui-open {
+  opacity: 1;
+}
+
+.dialog-content.ui-closed {
+  opacity: 0;
 }
 
 .dialog-body {
-  align-items: center;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  padding-left: 16px;
+  padding-right: 16px;
+  row-gap: 12px;
   margin-bottom: 20px;
 }
 
 .dialog-title {
   font-size: 18px;
   font-weight: 600;
-  color: #fff;
-  margin-bottom: 8px;
+  color: var(--content, #fff);
 }
 
 .dialog-desc {
   font-size: 14px;
-  color: #aaa;
-  text-align: center;
+  color: var(--content-muted, #aaa);
 }
 
 .dialog-close-btn {
-  padding: 10px 24px;
-  background-color: #e94560;
-  border-radius: 8px;
+  width: 80%;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  background-color: var(--primary, #e94560);
+  transition: background-color 150ms ease;
 }
 
-/* Sheet */
+.dialog-close-btn.ui-active {
+  background-color: var(--primary-2);
+}
+
+/* =========================
+ * Sheet
+ * ========================= */
+
 .sheet-viewport {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  width: 100%;
+  height: 100%;
 }
 
 .sheet-backdrop {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: var(--backdrop, rgba(0, 0, 0, 0.5));
 }
 
 .sheet-content {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  background-color: #16213e;
-  border-top-left-radius: 16px;
-  border-top-right-radius: 16px;
+  background-color: var(--canvas, #16213e);
+  border-top-left-radius: 36px;
+  border-top-right-radius: 36px;
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.08);
 }
 
 .sheet-inner-content {
-  padding: 16px;
+  padding-top: 8px;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-bottom: 48px;
+  display: flex;
+  flex-direction: column;
+  justify-content: start;
+  align-items: center;
+  gap: 16px;
 }
 
 .sheet-handle {
-  width: 40px;
+  width: 48px;
   height: 4px;
-  background-color: #666;
-  border-radius: 2px;
+  background-color: var(--content-faint, #666);
   align-self: center;
-  margin-top: 8px;
-  margin-bottom: 16px;
+  border-radius: 2px;
 }
 
 .sheet-body {
-  padding: 8px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
   align-items: center;
   gap: 12px;
 }
 
-/* Popover */
+/* =========================
+ * Popover
+ * ========================= */
+
 .popover-trigger {
   align-self: flex-start;
 }
 
 .popover-positioner {
-  margin-top: 4px;
+  width: max-content;
+  height: max-content;
+  transform-origin: top center;
+}
+
+.popover-positioner.ui-open {
+  animation: popover-in 150ms ease forwards;
+}
+
+.popover-positioner.ui-closed {
+  animation: popover-out 120ms ease forwards;
+}
+
+@keyframes popover-in {
+  0% {
+    opacity: 0;
+    transform: translateY(-16px) scale(0);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes popover-out {
+  0% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-8px) scale(0);
+  }
 }
 
 .popover-content {
-  background-color: #0f3460;
-  border-radius: 8px;
-  padding: 12px 16px;
-  border: 1px solid #333;
+  width: 240px;
+  display: flex;
+  flex-direction: column;
+  padding: 16px 20px;
+  border-radius: 16px;
+  background-color: var(--paper, #0f3460);
+  box-shadow:
+    0 10px 15px -3px rgba(0, 0, 0, 0.1),
+    0 4px 6px -4px rgba(0, 0, 0, 0.1);
 }
 
 .popover-body {
-  max-width: 200px;
+  width: 100%;
 }
 
 .popover-text {
   font-size: 13px;
-  color: #ccc;
+  color: var(--content-2, #ccc);
 }
 
-/* Swiper */
+/* =========================
+ * Swiper
+ * ========================= */
+
 .swiper-card {
   width: 100%;
   height: 150px;
   border-radius: 12px;
+  display: flex;
   align-items: center;
   justify-content: center;
 }
@@ -469,12 +630,17 @@
   color: #fff;
 }
 
-/* ScrollView */
+/* =========================
+ * ScrollView
+ * ========================= */
+
 .gallery-scroll-view {
   height: 80px;
 }
 
 .scroll-content-h {
+  width: max-content;
+  height: 100%;
   display: flex;
   flex-direction: row;
   gap: 10px;
@@ -484,8 +650,9 @@
 .scroll-item {
   width: 56px;
   height: 56px;
-  border-radius: 28px;
-  background-color: #0f3460;
+  border-radius: 9999px;
+  background-color: var(--neutral-faint, #0f3460);
+  display: flex;
   align-items: center;
   justify-content: center;
 }
@@ -493,10 +660,13 @@
 .scroll-item-text {
   font-size: 18px;
   font-weight: 600;
-  color: #e94560;
+  color: var(--primary, #e94560);
 }
 
-/* SwipeAction */
+/* =========================
+ * SwipeAction
+ * ========================= */
+
 .swipe-container {
   height: 60px;
   border-radius: 8px;
@@ -504,39 +674,51 @@
 }
 
 .swipe-action {
+  width: 100%;
   height: 60px;
 }
 
 .swipe-display {
-  height: 60px;
-  background-color: #0f3460;
+  width: 100vw;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  background: linear-gradient(
+    270deg,
+    var(--gradient-b, #e94560) 0%,
+    var(--gradient-a, #0f3460) 100%
+  );
   padding: 0 16px;
-  justify-content: center;
 }
 
 .swipe-display-text {
   font-size: 14px;
-  color: #ccc;
+  color: var(--neutral-content, #ccc);
 }
 
 .swipe-action-area {
   width: 80px;
-  height: 60px;
-  background-color: #e94560;
+  height: 100%;
+  background-color: var(--neutral, #555);
+  display: flex;
   align-items: center;
   justify-content: center;
+  box-shadow: -4px 0 4px 0 rgba(0, 0, 0, 0.08);
 }
 
 .swipe-action-text {
   font-size: 14px;
   font-weight: 600;
-  color: #fff;
+  color: var(--neutral-content, #fff);
 }
 
-/* Draggable */
+/* =========================
+ * Draggable
+ * ========================= */
+
 .draggable-area {
   height: 160px;
-  background-color: #0f3460;
+  background-color: var(--canvas, #0f3460);
   border-radius: 8px;
   padding: 16px;
   display: flex;
@@ -551,48 +733,73 @@
 .draggable-box {
   width: 100px;
   height: 100px;
-  background-color: #e94560;
   border-radius: 12px;
+  display: flex;
   align-items: center;
   justify-content: center;
+  background: linear-gradient(
+    150deg,
+    var(--primary) 8.42%,
+    var(--primary-2) 81.71%
+  );
 }
 
 .draggable-box-alt {
-  background-color: #4ecdc4;
+  background: linear-gradient(
+    150deg,
+    var(--secondary, #4ecdc4) 8.42%,
+    var(--secondary-2, #2ea89e) 81.71%
+  );
 }
 
 .draggable-text {
   font-size: 12px;
   font-weight: 600;
-  color: #fff;
+  color: var(--primary-content, #fff);
   text-align: center;
 }
 
-/* Sortable */
+/* =========================
+ * Sortable
+ * ========================= */
+
 .sortable-boundary {
   border-radius: 8px;
   overflow: hidden;
 }
 
 .sortable-item {
+  display: flex;
+  flex-direction: row;
+  justify-content: end;
+  align-items: center;
+  width: 100%;
   height: 48px;
-  background-color: #0f3460;
-  border-bottom: 1px solid #1a1a2e;
+  background-color: var(--neutral-faint, #0f3460);
+  border-bottom: 1px solid var(--line, #1a1a2e);
 }
 
 .sortable-item-area {
-  height: 48px;
-  padding: 0 16px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
   justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 0 16px;
 }
 
 .sortable-item-text {
   font-size: 14px;
-  color: #ccc;
+  color: var(--content-2, #ccc);
 }
 
-/* List */
+/* =========================
+ * List
+ * ========================= */
+
 .gallery-list {
+  width: 100%;
   height: 200px;
   border-radius: 8px;
   overflow: hidden;
@@ -601,18 +808,23 @@
 .list-item {
   height: 44px;
   padding: 0 16px;
-  background-color: #0f3460;
-  border-bottom: 1px solid #1a1a2e;
-  justify-content: center;
+  background-color: var(--neutral-faint, #0f3460);
+  border-bottom: 1px solid var(--line, #1a1a2e);
+  display: flex;
+  align-items: center;
 }
 
 .list-item-text {
   font-size: 14px;
-  color: #ccc;
+  color: var(--content-2, #ccc);
 }
 
-/* FeedList */
+/* =========================
+ * FeedList
+ * ========================= */
+
 .feed-list {
+  width: 100%;
   height: 220px;
   border-radius: 8px;
   overflow: hidden;
@@ -621,37 +833,43 @@
 .feed-item {
   height: 52px;
   padding: 0 16px;
-  background-color: #0f3460;
-  border-bottom: 1px solid #1a1a2e;
-  justify-content: center;
+  background-color: var(--neutral-faint, #0f3460);
+  border-bottom: 1px solid var(--line, #1a1a2e);
+  display: flex;
+  align-items: center;
 }
 
 .feed-item-text {
   font-size: 14px;
-  color: #ccc;
+  color: var(--content-2, #ccc);
 }
 
 .feed-footer {
   height: 44px;
+  display: flex;
   align-items: center;
   justify-content: center;
 }
 
 .feed-footer-text {
   font-size: 13px;
-  color: #888;
+  color: var(--content-muted, #888);
 }
 
-/* LazyComponent */
+/* =========================
+ * LazyComponent
+ * ========================= */
+
 .lazy-content {
   height: 80px;
-  background-color: #0f3460;
+  background-color: var(--neutral-faint, #0f3460);
   border-radius: 8px;
+  display: flex;
   align-items: center;
   justify-content: center;
 }
 
 .lazy-text {
   font-size: 14px;
-  color: #4ecdc4;
+  color: var(--secondary, #4ecdc4);
 }

--- a/examples/lynx-ui-gallery/src/App.tsx
+++ b/examples/lynx-ui-gallery/src/App.tsx
@@ -1,0 +1,56 @@
+import "./App.css";
+
+import { ButtonSection } from "./sections/ButtonSection.jsx";
+import { CheckboxSection } from "./sections/CheckboxSection.jsx";
+import { DialogSection } from "./sections/DialogSection.jsx";
+import { DraggableSection } from "./sections/DraggableSection.jsx";
+import { FeedListSection } from "./sections/FeedListSection.jsx";
+import { FormSection } from "./sections/FormSection.jsx";
+import { InputSection } from "./sections/InputSection.jsx";
+import { LazyComponentSection } from "./sections/LazyComponentSection.jsx";
+import { ListSection } from "./sections/ListSection.jsx";
+import { PopoverSection } from "./sections/PopoverSection.jsx";
+import { RadioGroupSection } from "./sections/RadioGroupSection.jsx";
+import { ScrollViewSection } from "./sections/ScrollViewSection.jsx";
+import { SheetSection } from "./sections/SheetSection.jsx";
+import { SliderSection } from "./sections/SliderSection.jsx";
+import { SortableSection } from "./sections/SortableSection.jsx";
+import { SwipeActionSection } from "./sections/SwipeActionSection.jsx";
+import { SwiperSection } from "./sections/SwiperSection.jsx";
+import { SwitchSection } from "./sections/SwitchSection.jsx";
+
+export function App() {
+  return (
+    <view className="gallery-container">
+      <scroll-view scroll-orientation="vertical" className="gallery-scroll">
+        <view className="gallery-header">
+          <text className="gallery-title">lynx-ui Gallery</text>
+          <text className="gallery-subtitle">Kitchen Sink Demo</text>
+        </view>
+
+        <ButtonSection />
+        <SwitchSection />
+        <CheckboxSection />
+        <RadioGroupSection />
+        <SliderSection />
+        <InputSection />
+        <DialogSection />
+        <SheetSection />
+        <PopoverSection />
+        <SwiperSection />
+        <ScrollViewSection />
+        <SwipeActionSection />
+        <DraggableSection />
+        <SortableSection />
+        <ListSection />
+        <FeedListSection />
+        <FormSection />
+        <LazyComponentSection />
+
+        <view className="gallery-footer">
+          <text className="gallery-footer-text">End of Gallery</text>
+        </view>
+      </scroll-view>
+    </view>
+  );
+}

--- a/examples/lynx-ui-gallery/src/index.tsx
+++ b/examples/lynx-ui-gallery/src/index.tsx
@@ -1,0 +1,10 @@
+import "@lynx-js/preact-devtools";
+import { root } from "@lynx-js/react";
+
+import { App } from "./App.jsx";
+
+root.render(<App />);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/lynx-ui-gallery/src/rspeedy-env.d.ts
+++ b/examples/lynx-ui-gallery/src/rspeedy-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@lynx-js/rspeedy/client" />

--- a/examples/lynx-ui-gallery/src/sections/ButtonSection.tsx
+++ b/examples/lynx-ui-gallery/src/sections/ButtonSection.tsx
@@ -1,0 +1,28 @@
+import { useState } from "@lynx-js/react";
+
+import { Button } from "@lynx-js/lynx-ui";
+
+export function ButtonSection() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <view className="section">
+      <text className="section-title">Button</text>
+      <view className="section-content">
+        <Button className="gallery-button" onClick={() => setCount((c) => c + 1)}>
+          {({ active = false }) => (
+            <view className={`btn ${active ? "btn-active" : ""}`}>
+              <text className="btn-text">Tap Count: {count}</text>
+            </view>
+          )}
+        </Button>
+
+        <Button className="gallery-button" disabled>
+          <view className="btn btn-disabled">
+            <text className="btn-text">Disabled</text>
+          </view>
+        </Button>
+      </view>
+    </view>
+  );
+}

--- a/examples/lynx-ui-gallery/src/sections/CheckboxSection.tsx
+++ b/examples/lynx-ui-gallery/src/sections/CheckboxSection.tsx
@@ -1,0 +1,62 @@
+import { useState } from "@lynx-js/react";
+
+import { Checkbox, CheckboxIndicator } from "@lynx-js/lynx-ui";
+
+export function CheckboxSection() {
+  const [checked, setChecked] = useState(false);
+  const [items, setItems] = useState<string[]>(["Apple"]);
+
+  const FRUITS = ["Apple", "Banana", "Orange"];
+  const allSelected = items.length === FRUITS.length;
+
+  return (
+    <view className="section">
+      <text className="section-title">Checkbox</text>
+      <view className="section-content">
+        <view className="row">
+          <Checkbox
+            className="checkbox"
+            checked={checked}
+            onChange={(value: boolean) => setChecked(value)}
+          >
+            <CheckboxIndicator className="checkbox-indicator">
+              <view className="checkmark" />
+            </CheckboxIndicator>
+          </Checkbox>
+          <text className="row-label">{checked ? "Checked" : "Unchecked"}</text>
+        </view>
+
+        <text className="subsection-title">Multi-Select</text>
+        <view className="row">
+          <Checkbox
+            className="checkbox"
+            checked={allSelected}
+            indeterminate={items.length > 0 && !allSelected}
+            onChange={(val: boolean) => setItems(val ? FRUITS : [])}
+          >
+            <CheckboxIndicator className="checkbox-indicator">
+              <view className={allSelected ? "checkmark" : "indeterminate-mark"} />
+            </CheckboxIndicator>
+          </Checkbox>
+          <text className="row-label">Select All</text>
+        </view>
+        {FRUITS.map((fruit) => (
+          <view key={fruit} className="row row-indent">
+            <Checkbox
+              className="checkbox"
+              checked={items.includes(fruit)}
+              onChange={(val: boolean) => {
+                setItems((prev) => val ? [...prev, fruit] : prev.filter((x) => x !== fruit));
+              }}
+            >
+              <CheckboxIndicator className="checkbox-indicator">
+                <view className="checkmark" />
+              </CheckboxIndicator>
+            </Checkbox>
+            <text className="row-label">{fruit}</text>
+          </view>
+        ))}
+      </view>
+    </view>
+  );
+}

--- a/examples/lynx-ui-gallery/src/sections/DialogSection.tsx
+++ b/examples/lynx-ui-gallery/src/sections/DialogSection.tsx
@@ -1,0 +1,35 @@
+import { useState } from "@lynx-js/react";
+
+import { DialogBackdrop, DialogClose, DialogContent, DialogRoot, DialogTrigger, DialogView } from "@lynx-js/lynx-ui";
+
+export function DialogSection() {
+  const [show, setShow] = useState(false);
+
+  return (
+    <view className="section">
+      <text className="section-title">Dialog</text>
+      <view className="section-content">
+        <DialogRoot show={show} onShowChange={setShow}>
+          <DialogTrigger className="dialog-trigger">
+            <text className="btn-text">Open Dialog</text>
+          </DialogTrigger>
+
+          <DialogView className="dialog-viewport">
+            <DialogBackdrop className="dialog-backdrop" />
+            <DialogContent className="dialog-content">
+              <view className="dialog-body">
+                <text className="dialog-title">Dialog Title</text>
+                <text className="dialog-desc">
+                  This is a dialog from lynx-ui. It supports backdrop dismissal and controlled visibility.
+                </text>
+              </view>
+              <DialogClose className="dialog-close-btn">
+                <text className="btn-text">Close</text>
+              </DialogClose>
+            </DialogContent>
+          </DialogView>
+        </DialogRoot>
+      </view>
+    </view>
+  );
+}

--- a/examples/lynx-ui-gallery/src/sections/DraggableSection.tsx
+++ b/examples/lynx-ui-gallery/src/sections/DraggableSection.tsx
@@ -1,0 +1,33 @@
+import { DraggableArea, DraggableRoot } from "@lynx-js/lynx-ui";
+
+export function DraggableSection() {
+  return (
+    <view className="section">
+      <text className="section-title">Draggable</text>
+      <view className="section-content">
+        <text className="row-label">Drag the boxes below</text>
+        <view className="draggable-area">
+          <DraggableRoot
+            className="draggable-item"
+            resetOnEnd={true}
+            trigger="immediate"
+          >
+            <DraggableArea className="draggable-box">
+              <text className="draggable-text">Drag (resets)</text>
+            </DraggableArea>
+          </DraggableRoot>
+
+          <DraggableRoot
+            className="draggable-item"
+            resetOnEnd={false}
+            trigger="immediate"
+          >
+            <DraggableArea className="draggable-box draggable-box-alt">
+              <text className="draggable-text">Drag (stays)</text>
+            </DraggableArea>
+          </DraggableRoot>
+        </view>
+      </view>
+    </view>
+  );
+}

--- a/examples/lynx-ui-gallery/src/sections/FeedListSection.tsx
+++ b/examples/lynx-ui-gallery/src/sections/FeedListSection.tsx
@@ -1,0 +1,74 @@
+import { useRef, useState } from "@lynx-js/react";
+
+import { FeedList } from "@lynx-js/lynx-ui";
+import type { FeedListRef } from "@lynx-js/lynx-ui";
+
+const INITIAL_ITEMS = Array.from({ length: 10 }, (_, i) => ({
+  id: `feed-${i}`,
+  label: `Feed Item ${i + 1}`,
+}));
+
+export function FeedListSection() {
+  const feedRef = useRef<FeedListRef>(null);
+  const [items, setItems] = useState(INITIAL_ITEMS);
+
+  const handleLoadMore = () => {
+    const len = items.length;
+    if (len >= 25) {
+      feedRef.current?.changeHasMoreStatus(false);
+      return;
+    }
+    setTimeout(() => {
+      setItems((prev) => [
+        ...prev,
+        ...Array.from({ length: 5 }, (_, i) => ({
+          id: `feed-${len + i}`,
+          label: `Feed Item ${len + i + 1}`,
+        })),
+      ]);
+    }, 500);
+  };
+
+  return (
+    <view className="section">
+      <text className="section-title">FeedList</text>
+      <view className="section-content">
+        <text className="row-label">Scroll to load more</text>
+        <FeedList
+          className="feed-list"
+          listId="galleryFeedList"
+          ref={feedRef}
+          listType="single"
+          spanCount={1}
+          scrollOrientation="vertical"
+          bounces={false}
+          upperThresholdItemCount={2}
+          lowerThresholdItemCount={2}
+          onLowerThresholdMeet={handleLoadMore}
+          loadMoreFooter={
+            <list-item key="footer" item-key="footer" full-span>
+              <view className="feed-footer">
+                <text className="feed-footer-text">Loading...</text>
+              </view>
+            </list-item>
+          }
+          noMoreDataFooter={
+            <list-item key="noMore" item-key="noMore" full-span>
+              <view className="feed-footer">
+                <text className="feed-footer-text">No more data</text>
+              </view>
+            </list-item>
+          }
+        >
+          {items.map((item) => (
+            <list-item key={item.id} item-key={item.id}>
+              <view className="feed-item">
+                <text className="feed-item-text">{item.label}</text>
+              </view>
+            </list-item>
+          ))}
+        </FeedList>
+      </view>
+    </view>
+  );
+}

--- a/examples/lynx-ui-gallery/src/sections/FormSection.tsx
+++ b/examples/lynx-ui-gallery/src/sections/FormSection.tsx
@@ -59,12 +59,14 @@ export function FormSection() {
             </FormField>
           </view>
 
-          <FormField as="Checkbox" name="agree" className="checkbox">
-            <CheckboxIndicator className="checkbox-indicator">
-              <view className="checkmark" />
-            </CheckboxIndicator>
+          <view className="row">
+            <FormField as="Checkbox" name="agree" className="checkbox">
+              <CheckboxIndicator className="checkbox-indicator">
+                <view className="checkmark" />
+              </CheckboxIndicator>
+            </FormField>
             <text className="row-label">I agree to terms</text>
-          </FormField>
+          </view>
 
           <view className="row">
             <FormField as="Switch" name="notify" className="switch">

--- a/examples/lynx-ui-gallery/src/sections/FormSection.tsx
+++ b/examples/lynx-ui-gallery/src/sections/FormSection.tsx
@@ -1,0 +1,95 @@
+import { useState } from "@lynx-js/react";
+
+import {
+  CheckboxIndicator,
+  FormField,
+  FormRoot,
+  FormSubmitButton,
+  Radio,
+  RadioIndicator,
+  SwitchThumb,
+  SwitchTrack,
+} from "@lynx-js/lynx-ui";
+
+export function FormSection() {
+  const [result, setResult] = useState("");
+
+  return (
+    <view className="section">
+      <text className="section-title">Form</text>
+      <view className="section-content">
+        <FormRoot
+          initialValues={{
+            username: "",
+            color: "red",
+            agree: false,
+            notify: false,
+          }}
+          onChanged={(values: Record<string, unknown>) => {
+            setResult(JSON.stringify(values));
+          }}
+        >
+          <view className="field">
+            <text className="field-label">Username</text>
+            <view className="input-container">
+              <FormField
+                as="Input"
+                name="username"
+                className="input"
+                placeholder="Enter username"
+              />
+            </view>
+          </view>
+
+          <view className="field">
+            <text className="field-label">Color</text>
+            <FormField as="RadioGroupRoot" name="color">
+              <view className="radio-group">
+                {["red", "green", "blue"].map((c) => (
+                  <view key={c} className="row">
+                    <Radio className="radio-item" value={c}>
+                      <RadioIndicator className="radio-indicator">
+                        <view className="radio-dot" />
+                      </RadioIndicator>
+                    </Radio>
+                    <text className="row-label">{c}</text>
+                  </view>
+                ))}
+              </view>
+            </FormField>
+          </view>
+
+          <FormField as="Checkbox" name="agree" className="checkbox">
+            <CheckboxIndicator className="checkbox-indicator">
+              <view className="checkmark" />
+            </CheckboxIndicator>
+            <text className="row-label">I agree to terms</text>
+          </FormField>
+
+          <view className="row">
+            <FormField as="Switch" name="notify" className="switch">
+              <SwitchTrack className="switch-track" />
+              <SwitchThumb className="switch-thumb" />
+            </FormField>
+            <text className="row-label">Notifications</text>
+          </view>
+
+          <FormSubmitButton
+            className="gallery-button"
+            onSubmit={(values) => {
+              setResult(JSON.stringify(values));
+            }}
+          >
+            <view className="btn">
+              <text className="btn-text">Submit</text>
+            </view>
+          </FormSubmitButton>
+        </FormRoot>
+
+        {result
+          ? <text className="row-label">Result: {result}</text>
+          : null}
+      </view>
+    </view>
+  );
+}

--- a/examples/lynx-ui-gallery/src/sections/InputSection.tsx
+++ b/examples/lynx-ui-gallery/src/sections/InputSection.tsx
@@ -1,0 +1,36 @@
+import { useState } from "@lynx-js/react";
+
+import { Input, TextArea } from "@lynx-js/lynx-ui";
+
+export function InputSection() {
+  const [controlledValue, setControlledValue] = useState("Hello");
+
+  return (
+    <view className="section">
+      <text className="section-title">Input & TextArea</text>
+      <view className="section-content">
+        <view className="field">
+          <text className="field-label">Basic Input</text>
+          <Input className="input" placeholder="Type here..." />
+        </view>
+
+        <view className="field">
+          <text className="field-label">Controlled: {controlledValue}</text>
+          <Input
+            className="input"
+            value={controlledValue}
+            onInput={setControlledValue}
+            placeholder="Controlled input"
+          />
+        </view>
+
+        <view className="field">
+          <text className="field-label">TextArea</text>
+          <view className="textarea-wrap">
+            <TextArea className="textarea" placeholder="Write something..." />
+          </view>
+        </view>
+      </view>
+    </view>
+  );
+}

--- a/examples/lynx-ui-gallery/src/sections/LazyComponentSection.tsx
+++ b/examples/lynx-ui-gallery/src/sections/LazyComponentSection.tsx
@@ -1,0 +1,42 @@
+import { useState } from "@lynx-js/react";
+
+import { LazyComponent } from "@lynx-js/lynx-ui";
+import { Button } from "@lynx-js/lynx-ui";
+
+export function LazyComponentSection() {
+  const [showHeavy, setShowHeavy] = useState(false);
+
+  return (
+    <view className="section">
+      <text className="section-title">LazyComponent</text>
+      <view className="section-content">
+        <text className="row-label">
+          Defers rendering until visibility threshold is met
+        </text>
+        <Button
+          className="gallery-button"
+          onClick={() => setShowHeavy(!showHeavy)}
+        >
+          <view className="btn">
+            <text className="btn-text">
+              {showHeavy ? "Hide" : "Show"} Lazy Content
+            </text>
+          </view>
+        </Button>
+        {showHeavy && (
+          <LazyComponent
+            pid="gallery-lazy"
+            scene="demo"
+            estimatedStyle={{ height: 80 }}
+          >
+            <view className="lazy-content">
+              <text className="lazy-text">
+                This content was lazily loaded!
+              </text>
+            </view>
+          </LazyComponent>
+        )}
+      </view>
+    </view>
+  );
+}

--- a/examples/lynx-ui-gallery/src/sections/ListSection.tsx
+++ b/examples/lynx-ui-gallery/src/sections/ListSection.tsx
@@ -1,0 +1,33 @@
+import { List } from "@lynx-js/lynx-ui";
+
+const DATA = Array.from({ length: 20 }, (_, i) => ({
+  id: String(i),
+  label: `List Item ${i + 1}`,
+}));
+
+export function ListSection() {
+  return (
+    <view className="section">
+      <text className="section-title">List</text>
+      <view className="section-content">
+        <text className="row-label">Virtualized List (20 items)</text>
+        <List
+          className="gallery-list"
+          listId="galleryList"
+          listType="single"
+          spanCount={1}
+          scrollOrientation="vertical"
+          bounces={false}
+        >
+          {DATA.map((item) => (
+            <list-item key={item.id} item-key={item.id}>
+              <view className="list-item">
+                <text className="list-item-text">{item.label}</text>
+              </view>
+            </list-item>
+          ))}
+        </List>
+      </view>
+    </view>
+  );
+}

--- a/examples/lynx-ui-gallery/src/sections/PopoverSection.tsx
+++ b/examples/lynx-ui-gallery/src/sections/PopoverSection.tsx
@@ -1,0 +1,38 @@
+import { useState } from "@lynx-js/react";
+
+import { PopoverContent, PopoverPositioner, PopoverRoot, PopoverTrigger } from "@lynx-js/lynx-ui";
+
+export function PopoverSection() {
+  const [show, setShow] = useState(false);
+
+  return (
+    <view className="section">
+      <text className="section-title">Popover</text>
+      <view className="section-content">
+        <PopoverRoot
+          show={show}
+          onVisibleChange={(visible: boolean) => setShow(visible)}
+        >
+          <PopoverTrigger className="popover-trigger">
+            <view className="btn">
+              <text className="btn-text">Tap for Popover</text>
+            </view>
+            <PopoverPositioner
+              placement="bottom"
+              placementOffset={8}
+              className="popover-positioner"
+            >
+              <PopoverContent className="popover-content">
+                <view className="popover-body">
+                  <text className="popover-text">
+                    This popover is anchored to the trigger button above.
+                  </text>
+                </view>
+              </PopoverContent>
+            </PopoverPositioner>
+          </PopoverTrigger>
+        </PopoverRoot>
+      </view>
+    </view>
+  );
+}

--- a/examples/lynx-ui-gallery/src/sections/RadioGroupSection.tsx
+++ b/examples/lynx-ui-gallery/src/sections/RadioGroupSection.tsx
@@ -1,0 +1,32 @@
+import { useState } from "@lynx-js/react";
+
+import { Radio, RadioGroupRoot, RadioIndicator } from "@lynx-js/lynx-ui";
+
+const OPTIONS = ["Option A", "Option B", "Option C", "Option D"];
+
+export function RadioGroupSection() {
+  const [value, setValue] = useState(OPTIONS[0]);
+
+  return (
+    <view className="section">
+      <text className="section-title">RadioGroup</text>
+      <view className="section-content">
+        <text className="row-label">Selected: {value}</text>
+        <RadioGroupRoot value={value} onValueChange={setValue}>
+          <view className="radio-group">
+            {OPTIONS.map((option) => (
+              <view key={option} className="row">
+                <Radio className="radio-item" value={option}>
+                  <RadioIndicator className="radio-indicator">
+                    <view className="radio-dot" />
+                  </RadioIndicator>
+                </Radio>
+                <text className="row-label">{option}</text>
+              </view>
+            ))}
+          </view>
+        </RadioGroupRoot>
+      </view>
+    </view>
+  );
+}

--- a/examples/lynx-ui-gallery/src/sections/ScrollViewSection.tsx
+++ b/examples/lynx-ui-gallery/src/sections/ScrollViewSection.tsx
@@ -1,0 +1,23 @@
+import { ScrollView } from "@lynx-js/lynx-ui";
+
+const ITEMS = Array.from({ length: 12 }, (_, i) => String.fromCharCode(65 + i));
+
+export function ScrollViewSection() {
+  return (
+    <view className="section">
+      <text className="section-title">ScrollView</text>
+      <view className="section-content">
+        <text className="row-label">Horizontal Scroll</text>
+        <ScrollView scrollOrientation="horizontal" className="gallery-scroll-view">
+          <view className="scroll-content-h">
+            {ITEMS.map((letter, i) => (
+              <view key={`h-${i}`} className="scroll-item">
+                <text className="scroll-item-text">{letter}</text>
+              </view>
+            ))}
+          </view>
+        </ScrollView>
+      </view>
+    </view>
+  );
+}

--- a/examples/lynx-ui-gallery/src/sections/SheetSection.tsx
+++ b/examples/lynx-ui-gallery/src/sections/SheetSection.tsx
@@ -1,0 +1,53 @@
+import { useRef } from "@lynx-js/react";
+
+import { SheetBackdrop, SheetContent, SheetHandle, SheetRoot, SheetView } from "@lynx-js/lynx-ui";
+import type { SheetRootRef } from "@lynx-js/lynx-ui";
+
+import { Button } from "@lynx-js/lynx-ui";
+
+export function SheetSection() {
+  const sheetRef = useRef<SheetRootRef>(null);
+
+  return (
+    <view className="section">
+      <text className="section-title">Sheet</text>
+      <view className="section-content">
+        <Button className="gallery-button" onClick={() => sheetRef.current?.open()}>
+          <view className="btn">
+            <text className="btn-text">Open Bottom Sheet</text>
+          </view>
+        </Button>
+
+        <SheetRoot
+          ref={sheetRef}
+          snapPoints={["40%", "80%"]}
+          initialSnap={0}
+        >
+          <SheetView className="sheet-viewport">
+            <SheetBackdrop className="sheet-backdrop" />
+            <SheetContent
+              className="sheet-content"
+              innerClassName="sheet-inner-content"
+            >
+              <SheetHandle className="sheet-handle" />
+              <view className="sheet-body">
+                <text className="dialog-title">Bottom Sheet</text>
+                <text className="dialog-desc">
+                  Drag to expand or swipe down to close. Supports multiple snap points at 40% and 80%.
+                </text>
+                <Button
+                  className="gallery-button"
+                  onClick={() => sheetRef.current?.close()}
+                >
+                  <view className="btn">
+                    <text className="btn-text">Close</text>
+                  </view>
+                </Button>
+              </view>
+            </SheetContent>
+          </SheetView>
+        </SheetRoot>
+      </view>
+    </view>
+  );
+}

--- a/examples/lynx-ui-gallery/src/sections/SliderSection.tsx
+++ b/examples/lynx-ui-gallery/src/sections/SliderSection.tsx
@@ -1,0 +1,56 @@
+import { useState } from "@lynx-js/react";
+
+import { SliderIndicator, SliderRoot, SliderThumb, SliderTrack } from "@lynx-js/lynx-ui";
+
+export function SliderSection() {
+  const [value, setValue] = useState(0.5);
+  const [steppedValue, setSteppedValue] = useState(0.5);
+
+  return (
+    <view className="section">
+      <text className="section-title">Slider</text>
+      <view className="section-content">
+        <text className="row-label">Value: {Math.round(value * 100)}%</text>
+        <SliderRoot
+          className="slider-root"
+          defaultValue={0.5}
+          onValueChange={(v: number) => setValue(v)}
+        >
+          <SliderTrack className="slider-track">
+            <SliderIndicator className="slider-indicator" />
+            <SliderThumb className="slider-thumb-wrapper">
+              <view className="slider-thumb" />
+            </SliderThumb>
+          </SliderTrack>
+        </SliderRoot>
+
+        <text className="row-label">
+          Stepped (10%): {Math.round(steppedValue * 100)}%
+        </text>
+        <SliderRoot
+          className="slider-root"
+          value={steppedValue}
+          step={0.1}
+          onValueChange={(v: number) => setSteppedValue(v)}
+        >
+          <SliderTrack className="slider-track">
+            <SliderIndicator className="slider-indicator" />
+            <SliderThumb className="slider-thumb-wrapper">
+              <view className="slider-thumb" />
+            </SliderThumb>
+          </SliderTrack>
+        </SliderRoot>
+
+        <text className="row-label">Disabled</text>
+        <SliderRoot className="slider-root" defaultValue={0.3} disabled>
+          <SliderTrack className="slider-track">
+            <SliderIndicator className="slider-indicator" />
+            <SliderThumb className="slider-thumb-wrapper">
+              <view className="slider-thumb" />
+            </SliderThumb>
+          </SliderTrack>
+        </SliderRoot>
+      </view>
+    </view>
+  );
+}

--- a/examples/lynx-ui-gallery/src/sections/SortableSection.tsx
+++ b/examples/lynx-ui-gallery/src/sections/SortableSection.tsx
@@ -1,0 +1,55 @@
+import { useState } from "@lynx-js/react";
+
+import { SortableItem, SortableItemArea, SortableRoot } from "@lynx-js/lynx-ui";
+import type { SortableData } from "@lynx-js/lynx-ui";
+
+interface DemoItem {
+  id: string;
+  label: string;
+}
+
+function createData(): SortableData<DemoItem>[] {
+  return Array.from({ length: 5 }, (_, i) => ({
+    getSortingKey: () => `item-${i}`,
+    dataItem: { id: `item-${i}`, label: `Item ${i + 1}` },
+  }));
+}
+
+export function SortableSection() {
+  const [data, setData] = useState<SortableData<DemoItem>[]>(createData);
+
+  return (
+    <view className="section">
+      <text className="section-title">Sortable</text>
+      <view className="section-content">
+        <text className="row-label">Long-press & drag to reorder</text>
+        <view
+          className="sortable-boundary"
+          id="sortableBoundary"
+          style={{ zIndex: "0" }}
+        >
+          <SortableRoot
+            data={data}
+            boundaryId="sortableBoundary"
+            onSortEnd={(sortedData: SortableData<DemoItem>[]) => setData(sortedData)}
+          >
+            {(item: SortableData<DemoItem>) => (
+              <SortableItem
+                key={item.getSortingKey()}
+                as="DraggableRoot"
+                className="sortable-item"
+                sortingKey={item.getSortingKey()}
+              >
+                <SortableItemArea className="sortable-item-area">
+                  <text className="sortable-item-text">
+                    {item.dataItem.label}
+                  </text>
+                </SortableItemArea>
+              </SortableItem>
+            )}
+          </SortableRoot>
+        </view>
+      </view>
+    </view>
+  );
+}

--- a/examples/lynx-ui-gallery/src/sections/SwipeActionSection.tsx
+++ b/examples/lynx-ui-gallery/src/sections/SwipeActionSection.tsx
@@ -1,0 +1,54 @@
+import { useRef, useState } from "@lynx-js/react";
+
+import { Button, SwipeAction } from "@lynx-js/lynx-ui";
+import type { SwipeActionRef } from "@lynx-js/lynx-ui";
+
+export function SwipeActionSection() {
+  const swipeRef = useRef<SwipeActionRef>(null);
+  const [showAction, setShowAction] = useState(false);
+
+  return (
+    <view className="section">
+      <text className="section-title">SwipeAction</text>
+      <view className="section-content">
+        <text className="row-label">Swipe left or tap button</text>
+        <view className="swipe-container">
+          <SwipeAction
+            className="swipe-action"
+            swipeActionId="gallery-swipe"
+            ref={swipeRef}
+            enableSwipe={true}
+            displayArea={
+              <view className="swipe-display">
+                <text className="swipe-display-text">Swipe me left</text>
+              </view>
+            }
+            actionArea={
+              <view className="swipe-action-area">
+                <text className="swipe-action-text">Delete</text>
+              </view>
+            }
+            onAction={(id: string) => console.log("action", id)}
+          />
+        </view>
+        <Button
+          className="gallery-button"
+          onClick={() => {
+            if (showAction) {
+              swipeRef.current?.closeActionArea(true);
+            } else {
+              swipeRef.current?.showActionArea(true);
+            }
+            setShowAction(!showAction);
+          }}
+        >
+          <view className="btn">
+            <text className="btn-text">
+              {showAction ? "Hide Action" : "Show Action"}
+            </text>
+          </view>
+        </Button>
+      </view>
+    </view>
+  );
+}

--- a/examples/lynx-ui-gallery/src/sections/SwiperSection.tsx
+++ b/examples/lynx-ui-gallery/src/sections/SwiperSection.tsx
@@ -1,0 +1,45 @@
+import { useState } from "@lynx-js/react";
+
+import { Swiper, SwiperItem } from "@lynx-js/lynx-ui";
+
+const ITEMS = [1, 2, 3, 4, 5];
+const COLORS = ["#FF6B6B", "#4ECDC4", "#45B7D1", "#96CEB4", "#FFEAA7"];
+
+export function SwiperSection() {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  return (
+    <view className="section">
+      <text className="section-title">Swiper</text>
+      <view className="section-content">
+        <text className="row-label">Current: {currentIndex + 1} / {ITEMS.length}</text>
+        <Swiper
+          data={ITEMS}
+          itemWidth={280}
+          containerWidth={350}
+          duration={400}
+          initialIndex={0}
+          onChange={setCurrentIndex}
+          mode="normal"
+          modeConfig={{
+            align: "center",
+            spaceBetween: 12,
+          }}
+          autoPlay={false}
+          style={{ overflow: "visible", height: "160px" }}
+        >
+          {({ index }) => (
+            <SwiperItem>
+              <view
+                className="swiper-card"
+                style={{ backgroundColor: COLORS[index % COLORS.length] }}
+              >
+                <text className="swiper-card-text">Card {index + 1}</text>
+              </view>
+            </SwiperItem>
+          )}
+        </Swiper>
+      </view>
+    </view>
+  );
+}

--- a/examples/lynx-ui-gallery/src/sections/SwitchSection.tsx
+++ b/examples/lynx-ui-gallery/src/sections/SwitchSection.tsx
@@ -1,0 +1,38 @@
+import { useState } from "@lynx-js/react";
+
+import { Switch, SwitchThumb, SwitchTrack } from "@lynx-js/lynx-ui";
+
+export function SwitchSection() {
+  const [checked, setChecked] = useState(true);
+
+  return (
+    <view className="section">
+      <text className="section-title">Switch</text>
+      <view className="section-content">
+        <view className="row">
+          <Switch className="switch" checked={checked} onChange={setChecked}>
+            <SwitchTrack className="switch-track" />
+            <SwitchThumb className="switch-thumb" />
+          </Switch>
+          <text className="row-label">Controlled: {checked ? "ON" : "OFF"}</text>
+        </view>
+
+        <view className="row">
+          <Switch className="switch">
+            <SwitchTrack className="switch-track" />
+            <SwitchThumb className="switch-thumb" />
+          </Switch>
+          <text className="row-label">Uncontrolled</text>
+        </view>
+
+        <view className="row">
+          <Switch className="switch" disabled defaultChecked>
+            <SwitchTrack className="switch-track" />
+            <SwitchThumb className="switch-thumb" />
+          </Switch>
+          <text className="row-label row-label-disabled">Disabled</text>
+        </view>
+      </view>
+    </view>
+  );
+}

--- a/examples/lynx-ui-gallery/tsconfig.json
+++ b/examples/lynx-ui-gallery/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "@lynx-js/react",
+
+    "module": "node16",
+    "moduleResolution": "node16",
+
+    "strict": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+  },
+  "exclude": ["dist/"],
+}

--- a/examples/react-devtool/lynx.config.ts
+++ b/examples/react-devtool/lynx.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "@lynx-js/rspeedy";
+
+import { pluginLynxConfig } from "@lynx-js/config-rsbuild-plugin";
+import { pluginQRCode } from "@lynx-js/qrcode-rsbuild-plugin";
+import { pluginReactLynx } from "@lynx-js/react-rsbuild-plugin";
+
+export default defineConfig({
+  plugins: [
+    pluginQRCode(),
+    pluginReactLynx({
+      enableNewGesture: true,
+    }),
+    pluginLynxConfig({
+      enableCSSInlineVariables: true,
+    }),
+  ],
+  output: {
+    filename: "[name].[platform].bundle",
+  },
+  environments: {
+    web: {},
+    lynx: {},
+  },
+});

--- a/examples/react-devtool/package.json
+++ b/examples/react-devtool/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@lynx-example/lynx-ui-gallery",
+  "name": "@lynx-example/react-devtool",
   "version": "0.1.0",
-  "description": "A Kitchen Sink gallery showcasing all lynx-ui components",
+  "description": "lynx-ui-gallery with @lynx-js/preact-devtools enabled",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
-    "directory": "examples/lynx-ui-gallery"
+    "directory": "examples/react-devtool"
   },
   "author": "Lynx Authors",
   "type": "module",
@@ -15,13 +15,15 @@
     "lynx.config.ts"
   ],
   "scripts": {
-    "build": "rspeedy build",
+    "build": "REACT_DEV=true rspeedy build",
     "dev": "rspeedy dev",
     "preview": "rspeedy preview"
   },
   "dependencies": {
+    "@lynx-example/lynx-ui-gallery": "workspace:*",
     "@lynx-js/luna-styles": "0.1.0",
     "@lynx-js/lynx-ui": "3.133.1",
+    "@lynx-js/preact-devtools": "5.0.1-20260525112551-dfe2d03",
     "@lynx-js/react": "catalog:"
   },
   "devDependencies": {

--- a/examples/react-devtool/src/index.tsx
+++ b/examples/react-devtool/src/index.tsx
@@ -1,6 +1,7 @@
+import "@lynx-js/preact-devtools";
 import { root } from "@lynx-js/react";
 
-import { App } from "./App.jsx";
+import { App } from "@lynx-example/lynx-ui-gallery/src/App.jsx";
 
 root.render(<App />);
 

--- a/examples/react-devtool/src/rspeedy-env.d.ts
+++ b/examples/react-devtool/src/rspeedy-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@lynx-js/rspeedy/client" />

--- a/examples/react-devtool/tsconfig.json
+++ b/examples/react-devtool/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "@lynx-js/react",
+
+    "module": "node16",
+    "moduleResolution": "node16",
+
+    "strict": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+  },
+  "exclude": ["dist/"],
+}

--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
     "overrides": {
       "@lynx-js/types": "catalog:"
     },
-    "ignoredBuiltDependencies": [
-      "core-js"
-    ],
     "patchedDependencies": {
       "@lynx-js/react-alias-rsbuild-plugin@0.16.3": "patches/@lynx-js__react-alias-rsbuild-plugin@0.16.3.patch",
       "@lynx-js/react-webpack-plugin@0.9.3": "patches/@lynx-js__react-webpack-plugin@0.9.3.patch"
-    }
+    },
+    "ignoredBuiltDependencies": [
+      "core-js"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
     },
     "ignoredBuiltDependencies": [
       "core-js"
-    ]
+    ],
+    "patchedDependencies": {
+      "@lynx-js/react-alias-rsbuild-plugin@0.16.3": "patches/@lynx-js__react-alias-rsbuild-plugin@0.16.3.patch",
+      "@lynx-js/react-webpack-plugin@0.9.3": "patches/@lynx-js__react-webpack-plugin@0.9.3.patch"
+    }
   }
 }

--- a/patches/@lynx-js__react-alias-rsbuild-plugin@0.16.3.patch
+++ b/patches/@lynx-js__react-alias-rsbuild-plugin@0.16.3.patch
@@ -1,0 +1,12 @@
+diff --git a/dist/index.js b/dist/index.js
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -429,7 +429,7 @@
+                 await Promise.all(transformedEntries.map((entry)=>`@lynx-js/react/${entry}`).map((entry)=>resolve(entry).then((value)=>{
+                         chain.resolve.alias.set(`${entry}$`, value);
+                     })));
+-                if (isProd) {
++                if (isProd && !process.env['REACT_DEV']) {
+                     chain.resolve.alias.set('@lynx-js/react/debug$', false);
+                     chain.resolve.alias.set('@lynx-js/preact-devtools$', false);
+                 }

--- a/patches/@lynx-js__react-webpack-plugin@0.9.3.patch
+++ b/patches/@lynx-js__react-webpack-plugin@0.9.3.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/ReactWebpackPlugin.js b/lib/ReactWebpackPlugin.js
+--- a/lib/ReactWebpackPlugin.js
++++ b/lib/ReactWebpackPlugin.js
+@@ -119,8 +119,10 @@
+         }).apply(compiler);
+         const isDev = process.env['NODE_ENV'] === 'development'
+             || compiler.options.mode === 'development';
++        // User can force __DEV__ to true by environment variable `REACT_DEV=true`
++        const isReactDev = Boolean(process.env['REACT_DEV']);
+         new DefinePlugin({
+-            __DEV__: isDev,
++            __DEV__: isDev || isReactDev,
+             // We enable profile by default in development.
+             // It can also be disabled by environment variable `REACT_PROFILE=false`
+             __PROFILE__: JSON.stringify(process.env['REACT_PROFILE']

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,7 +95,7 @@ importers:
         version: 4.0.0
       '@rsbuild/plugin-sass':
         specifier: 1.5.2
-        version: 1.5.2(@rsbuild/core@2.0.3(core-js@3.47.0))
+        version: 1.5.2(@rsbuild/core@1.7.5)
       '@types/react':
         specifier: ^18.3.28
         version: 18.3.28
@@ -837,6 +837,9 @@ importers:
 
   examples/lynx-ui-gallery:
     dependencies:
+      '@lynx-js/luna-styles':
+        specifier: 0.1.0
+        version: 0.1.0
       '@lynx-js/lynx-ui':
         specifier: 3.133.1
         version: 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28))(@lynx-js/types@4.0.0)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -847,6 +850,9 @@ importers:
         specifier: 'catalog:'
         version: 0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28)
     devDependencies:
+      '@lynx-js/config-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.0.2(@lynx-js/rspeedy@0.14.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(typescript@5.9.3)(webpack@5.101.3))
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: 'catalog:'
         version: 0.4.7
@@ -10376,6 +10382,16 @@ snapshots:
       '@rsbuild/core': 2.0.3(core-js@3.47.0)
     transitivePeerDependencies:
       - '@rspack/core'
+
+  '@rsbuild/plugin-sass@1.5.2(@rsbuild/core@1.7.5)':
+    dependencies:
+      deepmerge: 4.3.1
+      loader-utils: 2.0.4
+      postcss: 8.5.13
+      reduce-configs: 1.1.2
+      sass-embedded: 1.99.0
+    optionalDependencies:
+      '@rsbuild/core': 1.7.5
 
   '@rsbuild/plugin-sass@1.5.2(@rsbuild/core@2.0.3(core-js@3.47.0))':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,14 @@ catalogs:
 overrides:
   '@lynx-js/types': 4.0.0
 
+patchedDependencies:
+  '@lynx-js/react-alias-rsbuild-plugin@0.16.3':
+    hash: dd335059a6a6af00f788ce513573f1271a8f0fe0faa6e9490738cdd2cbef09e0
+    path: patches/@lynx-js__react-alias-rsbuild-plugin@0.16.3.patch
+  '@lynx-js/react-webpack-plugin@0.9.3':
+    hash: 33cba5d3ebabba872010920f9c4f2493c713bdf8a4c1fd3e3af5bac32871e5a0
+    path: patches/@lynx-js__react-webpack-plugin@0.9.3.patch
+
 importers:
 
   .:
@@ -9017,18 +9025,18 @@ snapshots:
 
   '@lynx-js/qrcode-rsbuild-plugin@0.4.7': {}
 
-  '@lynx-js/react-alias-rsbuild-plugin@0.16.3': {}
+  '@lynx-js/react-alias-rsbuild-plugin@0.16.3(patch_hash=dd335059a6a6af00f788ce513573f1271a8f0fe0faa6e9490738cdd2cbef09e0)': {}
 
-  '@lynx-js/react-refresh-webpack-plugin@0.3.6(@lynx-js/react-webpack-plugin@0.9.3(@lynx-js/react@0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28))(@lynx-js/template-webpack-plugin@0.11.2(tslib@2.8.1)))':
+  '@lynx-js/react-refresh-webpack-plugin@0.3.6(@lynx-js/react-webpack-plugin@0.9.3(patch_hash=33cba5d3ebabba872010920f9c4f2493c713bdf8a4c1fd3e3af5bac32871e5a0)(@lynx-js/react@0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28))(@lynx-js/template-webpack-plugin@0.11.2(tslib@2.8.1)))':
     dependencies:
-      '@lynx-js/react-webpack-plugin': 0.9.3(@lynx-js/react@0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28))(@lynx-js/template-webpack-plugin@0.11.2(tslib@2.8.1))
+      '@lynx-js/react-webpack-plugin': 0.9.3(patch_hash=33cba5d3ebabba872010920f9c4f2493c713bdf8a4c1fd3e3af5bac32871e5a0)(@lynx-js/react@0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28))(@lynx-js/template-webpack-plugin@0.11.2(tslib@2.8.1))
 
   '@lynx-js/react-rsbuild-plugin@0.16.3(@lynx-js/react@0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28))(tslib@2.8.1)(webpack@5.101.3)':
     dependencies:
       '@lynx-js/css-extract-webpack-plugin': 0.7.1(@lynx-js/template-webpack-plugin@0.11.2(tslib@2.8.1))(webpack@5.101.3)
-      '@lynx-js/react-alias-rsbuild-plugin': 0.16.3
-      '@lynx-js/react-refresh-webpack-plugin': 0.3.6(@lynx-js/react-webpack-plugin@0.9.3(@lynx-js/react@0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28))(@lynx-js/template-webpack-plugin@0.11.2(tslib@2.8.1)))
-      '@lynx-js/react-webpack-plugin': 0.9.3(@lynx-js/react@0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28))(@lynx-js/template-webpack-plugin@0.11.2(tslib@2.8.1))
+      '@lynx-js/react-alias-rsbuild-plugin': 0.16.3(patch_hash=dd335059a6a6af00f788ce513573f1271a8f0fe0faa6e9490738cdd2cbef09e0)
+      '@lynx-js/react-refresh-webpack-plugin': 0.3.6(@lynx-js/react-webpack-plugin@0.9.3(patch_hash=33cba5d3ebabba872010920f9c4f2493c713bdf8a4c1fd3e3af5bac32871e5a0)(@lynx-js/react@0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28))(@lynx-js/template-webpack-plugin@0.11.2(tslib@2.8.1)))
+      '@lynx-js/react-webpack-plugin': 0.9.3(patch_hash=33cba5d3ebabba872010920f9c4f2493c713bdf8a4c1fd3e3af5bac32871e5a0)(@lynx-js/react@0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28))(@lynx-js/template-webpack-plugin@0.11.2(tslib@2.8.1))
       '@lynx-js/runtime-wrapper-webpack-plugin': 0.1.3
       '@lynx-js/template-webpack-plugin': 0.11.2(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
       '@lynx-js/use-sync-external-store': 1.5.0(@lynx-js/react@0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28))
@@ -9063,7 +9071,7 @@ snapshots:
       - react
       - react-dom
 
-  '@lynx-js/react-webpack-plugin@0.9.3(@lynx-js/react@0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28))(@lynx-js/template-webpack-plugin@0.11.2(tslib@2.8.1))':
+  '@lynx-js/react-webpack-plugin@0.9.3(patch_hash=33cba5d3ebabba872010920f9c4f2493c713bdf8a4c1fd3e3af5bac32871e5a0)(@lynx-js/react@0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28))(@lynx-js/template-webpack-plugin@0.11.2(tslib@2.8.1))':
     dependencies:
       '@lynx-js/template-webpack-plugin': 0.11.2(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
       '@lynx-js/webpack-runtime-globals': 0.0.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,7 +95,7 @@ importers:
         version: 4.0.0
       '@rsbuild/plugin-sass':
         specifier: 1.5.2
-        version: 1.5.2(@rsbuild/core@1.7.5)
+        version: 1.5.2(@rsbuild/core@2.0.3(core-js@3.47.0))
       '@types/react':
         specifier: ^18.3.28
         version: 18.3.28
@@ -812,6 +812,37 @@ importers:
 
   examples/lynx-api:
     dependencies:
+      '@lynx-js/react':
+        specifier: 'catalog:'
+        version: 0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28)
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.4.7
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.16.3(@lynx-js/react@0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28))(tslib@2.8.1)(webpack@5.101.3)
+      '@lynx-js/rspeedy':
+        specifier: 'catalog:'
+        version: 0.14.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(typescript@5.9.3)(webpack@5.101.3)
+      '@lynx-js/types':
+        specifier: 4.0.0
+        version: 4.0.0
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+
+  examples/lynx-ui-gallery:
+    dependencies:
+      '@lynx-js/lynx-ui':
+        specifier: 3.133.1
+        version: 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28))(@lynx-js/types@4.0.0)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@lynx-js/preact-devtools':
+        specifier: 5.0.1-20260525112551-dfe2d03
+        version: 5.0.1-20260525112551-dfe2d03
       '@lynx-js/react':
         specifier: 'catalog:'
         version: 0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28)
@@ -2549,6 +2580,9 @@ packages:
     peerDependenciesMeta:
       '@lynx-js/types':
         optional: true
+
+  '@lynx-js/preact-devtools@5.0.1-20260525112551-dfe2d03':
+    resolution: {integrity: sha512-q6zlNTtYIA8jCGmnGE6umf6/caTiMa/tkjk+omaBX3Uj4JyIDuV/oWRi/UPDYS9VodBe4Fl6kWsZBQNAK9f9gQ==}
 
   '@lynx-js/qrcode-rsbuild-plugin@0.4.7':
     resolution: {integrity: sha512-7Y4jK5I7lbmzbmmBhXPbbFw+4+mAWkwqzF1+PKLSzgY9BPsnwuEyu4EsrRo7RqyXpgcpunacZC7IgyB6BRDh+g==}
@@ -4889,6 +4923,10 @@ packages:
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
+  errorstacks@2.4.2:
+    resolution: {integrity: sha512-aQAkABfX+AsCxWtvh1KGIDkTiYyABsTtZkBb8cd9FWxNnEdrcFEsTxUfi9sc0Jc1mgHC2kW3UtJVadqSuMm/uQ==}
+    engines: {node: '>=24'}
+
   es-abstract@1.24.0:
     resolution: {integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==}
     engines: {node: '>= 0.4'}
@@ -5278,6 +5316,9 @@ packages:
 
   hpack.js@2.1.6:
     resolution: {integrity: sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==}
+
+  htm@3.1.1:
+    resolution: {integrity: sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==}
 
   html-entities@2.3.3:
     resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
@@ -8963,6 +9004,11 @@ snapshots:
       - react
       - react-dom
 
+  '@lynx-js/preact-devtools@5.0.1-20260525112551-dfe2d03':
+    dependencies:
+      errorstacks: 2.4.2
+      htm: 3.1.1
+
   '@lynx-js/qrcode-rsbuild-plugin@0.4.7': {}
 
   '@lynx-js/react-alias-rsbuild-plugin@0.16.3': {}
@@ -10330,16 +10376,6 @@ snapshots:
       '@rsbuild/core': 2.0.3(core-js@3.47.0)
     transitivePeerDependencies:
       - '@rspack/core'
-
-  '@rsbuild/plugin-sass@1.5.2(@rsbuild/core@1.7.5)':
-    dependencies:
-      deepmerge: 4.3.1
-      loader-utils: 2.0.4
-      postcss: 8.5.13
-      reduce-configs: 1.1.2
-      sass-embedded: 1.99.0
-    optionalDependencies:
-      '@rsbuild/core': 1.7.5
 
   '@rsbuild/plugin-sass@1.5.2(@rsbuild/core@2.0.3(core-js@3.47.0))':
     dependencies:
@@ -11915,6 +11951,8 @@ snapshots:
     dependencies:
       stackframe: 1.3.4
 
+  errorstacks@2.4.2: {}
+
   es-abstract@1.24.0:
     dependencies:
       array-buffer-byte-length: 1.0.2
@@ -12405,6 +12443,8 @@ snapshots:
       obuf: 1.1.2
       readable-stream: 2.3.8
       wbuf: 1.7.3
+
+  htm@3.1.1: {}
 
   html-entities@2.3.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,7 +103,7 @@ importers:
         version: 4.0.0
       '@rsbuild/plugin-sass':
         specifier: 1.5.2
-        version: 1.5.2(@rsbuild/core@1.7.5)
+        version: 1.5.2(@rsbuild/core@2.0.3(core-js@3.47.0))
       '@types/react':
         specifier: ^18.3.28
         version: 18.3.28
@@ -851,9 +851,6 @@ importers:
       '@lynx-js/lynx-ui':
         specifier: 3.133.1
         version: 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28))(@lynx-js/types@4.0.0)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260525112551-dfe2d03
-        version: 5.0.1-20260525112551-dfe2d03
       '@lynx-js/react':
         specifier: 'catalog:'
         version: 0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28)
@@ -1094,6 +1091,46 @@ importers:
       '@rsbuild/plugin-sass':
         specifier: 1.5.2
         version: 1.5.2(@rsbuild/core@2.0.3(core-js@3.47.0))
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+
+  examples/react-devtool:
+    dependencies:
+      '@lynx-example/lynx-ui-gallery':
+        specifier: workspace:*
+        version: link:../lynx-ui-gallery
+      '@lynx-js/luna-styles':
+        specifier: 0.1.0
+        version: 0.1.0
+      '@lynx-js/lynx-ui':
+        specifier: 3.133.1
+        version: 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28))(@lynx-js/types@4.0.0)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@lynx-js/preact-devtools':
+        specifier: 5.0.1-20260525112551-dfe2d03
+        version: 5.0.1-20260525112551-dfe2d03
+      '@lynx-js/react':
+        specifier: 'catalog:'
+        version: 0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28)
+    devDependencies:
+      '@lynx-js/config-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.0.2(@lynx-js/rspeedy@0.14.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(typescript@5.9.3)(webpack@5.101.3))
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.4.7
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.16.3(@lynx-js/react@0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28))(tslib@2.8.1)(webpack@5.101.3)
+      '@lynx-js/rspeedy':
+        specifier: 'catalog:'
+        version: 0.14.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(typescript@5.9.3)(webpack@5.101.3)
+      '@lynx-js/types':
+        specifier: 4.0.0
+        version: 4.0.0
       '@types/react':
         specifier: ^18.3.28
         version: 18.3.28
@@ -10390,16 +10427,6 @@ snapshots:
       '@rsbuild/core': 2.0.3(core-js@3.47.0)
     transitivePeerDependencies:
       - '@rspack/core'
-
-  '@rsbuild/plugin-sass@1.5.2(@rsbuild/core@1.7.5)':
-    dependencies:
-      deepmerge: 4.3.1
-      loader-utils: 2.0.4
-      postcss: 8.5.13
-      reduce-configs: 1.1.2
-      sass-embedded: 1.99.0
-    optionalDependencies:
-      '@rsbuild/core': 1.7.5
 
   '@rsbuild/plugin-sass@1.5.2(@rsbuild/core@2.0.3(core-js@3.47.0))':
     dependencies:


### PR DESCRIPTION
## Summary

Add two new examples:

### `@lynx-example/lynx-ui-gallery`
A Kitchen Sink gallery showcasing **all** lynx-ui components:
Button, Switch, Checkbox, RadioGroup, Slider, Input/TextArea, Dialog, Sheet, Popover, Swiper, ScrollView, SwipeAction, Draggable, Sortable, List, FeedList, Form, and LazyComponent.

- Uses `@lynx-js/luna-styles` semantic tokens with proper theming
- CSS matches official lynx-ui example patterns (transitions, animations, ui-variants)
- Verified rendering on embedded-lynx via Lynx DevTool

### `@lynx-example/react-devtool`
Imports `App` from lynx-ui-gallery and adds `@lynx-js/preact-devtools`. Builds with `REACT_DEV=true` so devtools survive production bundling.

### `REACT_DEV` env var (pnpm patches)
Patches `@lynx-js/react-webpack-plugin` and `@lynx-js/react-alias-rsbuild-plugin` to support a `REACT_DEV` environment variable (similar to existing `REACT_PROFILE` / `REACT_ALOG`):
- `REACT_DEV=true` forces `__DEV__=true` in production builds
- Skips aliasing `@lynx-js/preact-devtools` and `@lynx-js/react/debug` to `false`
