### PR TITLE
fix: disable mangle in react-devtool for readable component names

### DIFF
--- a/.changeset/react-devtool-no-mangle.md
+++ b/.changeset/react-devtool-no-mangle.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/react-devtool": patch
+---
+
+Disable JavaScript mangle in the react-devtool example so component names remain readable in preact-devtools.

--- a/examples/react-devtool/lynx.config.ts
+++ b/examples/react-devtool/lynx.config.ts
@@ -16,6 +16,13 @@ export default defineConfig({
   ],
   output: {
     filename: "[name].[platform].bundle",
+    minify: {
+      jsOptions: {
+        minimizerOptions: {
+          mangle: false,
+        },
+      },
+    },
   },
   environments: {
     web: {},


### PR DESCRIPTION
Disable `mangle` in the react-devtool example's output config so that preact-devtools can display real component names (e.g. `ButtonSection`, `SwitchSection`) instead of minified identifiers.