### PR TITLE
docs(changelog): restore webassembly and backfill motion changelogs

### DIFF
--- a/examples/motion/CHANGELOG.md
+++ b/examples/motion/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lynx-example/motion
 
+## 0.2.2
+
+### Patch Changes
+
+- e52a572: Republish so changesets-based CI can publish the package normally (no functional changes; 0.2.1 was manually published outside changesets to work around an OIDC auth failure).
+
 ## 0.2.1
 
 ### Patch Changes

--- a/examples/webassembly/CHANGELOG.md
+++ b/examples/webassembly/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @lynx-example/webassembly
+
+## 0.2.0
+
+### Minor Changes
+
+- 8efc0f3: Add a WebAssembly example that runs an add function in Lynx.


### PR DESCRIPTION
## Summary

Audited every publishable package under `examples/` (57 total; 2 private skipped) for changelog coverage — comparing each `package.json` version against its `CHANGELOG.md`. Two were out of sync:

### `@lynx-example/webassembly` — CHANGELOG missing entirely
Its `CHANGELOG.md` was correctly generated by changesets in #327 (`Version Packages`), then accidentally **deleted** by #331 (`mark webassembly 0.2.0 released`), which added `publishConfig` but also stripped the 7-line changelog. Restored to the exact generated content.

### `@lynx-example/motion` — missing `0.2.2` entry
`package.json` is at `0.2.2` but the changelog stopped at `0.2.1`. `0.2.2` came from a manual version bump (`e52a572`) that skipped changesets (republish to recover from a manual `0.2.1` publish / OIDC auth workaround — no functional changes). Backfilled a Patch Changes entry so npm `0.2.2` has a matching changelog.

All other 53 publishable examples (incl. `video`) already have changelogs in sync with their versions.

## Test plan
- `package.json` version == top `CHANGELOG.md` version for both packages after this change.
- No code/version changes; changelog content only.