### PR TITLE
chore(examples): include CHANGELOG.md in published files

### DIFF
--- a/examples/7guis/package.json
+++ b/examples/7guis/package.json
@@ -15,7 +15,8 @@
     "dist",
     "src",
     "lynx.config.ts",
-    "tsconfig.json"
+    "tsconfig.json",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/BankCards/package.json
+++ b/examples/BankCards/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/Gallery/package.json
+++ b/examples/Gallery/package.json
@@ -14,7 +14,8 @@
     "dist/",
     "resource/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/a2ui/package.json
+++ b/examples/a2ui/package.json
@@ -12,7 +12,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "npm run catalog && rspeedy build",

--- a/examples/accessibility/package.json
+++ b/examples/accessibility/package.json
@@ -12,7 +12,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/action-sheet/package.json
+++ b/examples/action-sheet/package.json
@@ -12,7 +12,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/animation/package.json
+++ b/examples/animation/package.json
@@ -14,7 +14,8 @@
     "dist/",
     "src/",
     "lynx.web.config.mjs",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build && rspeedy build --config lynx.web.config.mjs",

--- a/examples/blur-view/package.json
+++ b/examples/blur-view/package.json
@@ -12,7 +12,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/composing-elements/package.json
+++ b/examples/composing-elements/package.json
@@ -12,7 +12,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/css/package.json
+++ b/examples/css/package.json
@@ -14,7 +14,8 @@
     "dist/",
     "resource/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/desktop/package.json
+++ b/examples/desktop/package.json
@@ -12,7 +12,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/element-manipulation/package.json
+++ b/examples/element-manipulation/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/event/package.json
+++ b/examples/event/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/external-bundle/package.json
+++ b/examples/external-bundle/package.json
@@ -14,7 +14,8 @@
     "dist/",
     "src/",
     "lynx.config.mjs",
-    "*.rslib.config.js"
+    "*.rslib.config.js",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "pnpm build:bundle && rspeedy build",

--- a/examples/fetch/package.json
+++ b/examples/fetch/package.json
@@ -13,7 +13,8 @@
     "dist/",
     "index.scss",
     "index.tsx",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/frame/package.json
+++ b/examples/frame/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -11,7 +11,8 @@
   "files": [
     "dist",
     "src",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/ifr/package.json
+++ b/examples/ifr/package.json
@@ -12,7 +12,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/image/package.json
+++ b/examples/image/package.json
@@ -12,7 +12,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/input/package.json
+++ b/examples/input/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build && rspeedy build --config lynx.web.config.mjs",

--- a/examples/layout/package.json
+++ b/examples/layout/package.json
@@ -14,7 +14,8 @@
     "dist/",
     "src/",
     "lynx.web.config.mjs",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build && rspeedy build --config lynx.web.config.mjs",

--- a/examples/lazy-bundle/package.json
+++ b/examples/lazy-bundle/package.json
@@ -11,7 +11,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/list/package.json
+++ b/examples/list/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/local-storage/package.json
+++ b/examples/local-storage/package.json
@@ -11,7 +11,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/lynx-api/package.json
+++ b/examples/lynx-api/package.json
@@ -12,7 +12,8 @@
     "dist/",
     "src/",
     "resource/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/lynx-ui-gallery/package.json
+++ b/examples/lynx-ui-gallery/package.json
@@ -12,7 +12,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/main-thread/package.json
+++ b/examples/main-thread/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/markdown/package.json
+++ b/examples/markdown/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/motion/package.json
+++ b/examples/motion/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/native-element/package.json
+++ b/examples/native-element/package.json
@@ -12,7 +12,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/networking/package.json
+++ b/examples/networking/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/overlay/package.json
+++ b/examples/overlay/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/page/package.json
+++ b/examples/page/package.json
@@ -12,7 +12,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/performance-api/package.json
+++ b/examples/performance-api/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/react-devtool/package.json
+++ b/examples/react-devtool/package.json
@@ -12,7 +12,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "REACT_DEV=true rspeedy build",

--- a/examples/react-lifecycle/package.json
+++ b/examples/react-lifecycle/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/refresh/package.json
+++ b/examples/refresh/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/scroll-coordinator/package.json
+++ b/examples/scroll-coordinator/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/scroll-view/package.json
+++ b/examples/scroll-view/package.json
@@ -12,7 +12,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/svg/package.json
+++ b/examples/svg/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/swiper/package.json
+++ b/examples/swiper/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/tanstack-router/package.json
+++ b/examples/tanstack-router/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/text/package.json
+++ b/examples/text/package.json
@@ -14,7 +14,8 @@
     "dist/",
     "src/",
     "assets/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/textarea/package.json
+++ b/examples/textarea/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/title-bar-view/package.json
+++ b/examples/title-bar-view/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/video/package.json
+++ b/examples/video/package.json
@@ -12,7 +12,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/view/package.json
+++ b/examples/view/package.json
@@ -12,7 +12,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/viewpager/package.json
+++ b/examples/viewpager/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/webassembly/package.json
+++ b/examples/webassembly/package.json
@@ -12,7 +12,8 @@
   "files": [
     "dist",
     "src",
-    "lynx.config.ts"
+    "lynx.config.ts",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/webview/package.json
+++ b/examples/webview/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",

--- a/examples/with-solidjs/package.json
+++ b/examples/with-solidjs/package.json
@@ -14,7 +14,8 @@
     "dist/",
     "src/",
     "rspack.config.ts",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspack build",

--- a/examples/zustand/package.json
+++ b/examples/zustand/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "src/",
-    "lynx.config.mjs"
+    "lynx.config.mjs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rspeedy build",


### PR DESCRIPTION
## Summary

The `files` allowlist in each example's `package.json` didn't include `CHANGELOG.md`, so the changeset-generated changelog was excluded from the published npm tarball.

Audited all example packages and added `"CHANGELOG.md"` to the `files` array of every publishable example that declares one — **52 packages**.

**Skipped (intentionally):**
- `design-guide` — already lists `CHANGELOG.md`.
- `i18n`, `tailwindcss` — no `files` field, so they already publish everything (changelog included).
- `vanilla`, `web-platform` — private, not published.

## Notes
- Changelog content itself is unchanged (it's changeset-generated, not hand-edited) — this only fixes which files get shipped.
- No changeset added: `package.json` is outside `.changeset/config.json`'s `changedFilePatterns` (`src/**`, `lynx.config.*`), so this metadata change doesn't trigger a release. The new `files` entry takes effect on each package's next publish.
- Verified `sort-package-json` (used by `meta-updater`) leaves the edited `files` arrays unchanged, so `meta-updater --test` stays green.

## Test plan
- `pnpm meta-updater --test` — package.json still normalized/sorted.
- `pnpm dprint check` — formatting unchanged.
- `npm pack` on any example now includes `CHANGELOG.md`.