### PR TITLE
feat: add AnimaX examples

### DIFF
--- a/.changeset/fair-lions-animate.md
+++ b/.changeset/fair-lions-animate.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/animax": minor
+---
+
+Add AnimaX examples covering JSON playback, network src loading, UI methods, frame segments, and progress updates.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This repository is intended to showcase examples of Lynx.
   - [`input`]: An example shows how to use input
   - [`textarea`]: An example shows how to use textarea
   - [`overlay`]: An example shows how to use overlay
+  - [`animax`]: An example shows how to use `<animax-view>` in Lynx
   - [`svg`]: An example shows how to use svg
   - [`video`]: An example shows how to use `<video>` in Lynx
   - [`markdown`]: An example show how to use markdown
@@ -69,6 +70,7 @@ This repository is intended to showcase examples of Lynx.
 
 [`7guis`]: ./examples/7guis
 [`action-sheet`]: ./examples/action-sheet
+[`animax`]: ./examples/animax
 [`animation`]: ./examples/animation
 [`blur-view`]: ./examples/blur-view
 [`css`]: ./examples/css

--- a/examples/animax/README.md
+++ b/examples/animax/README.md
@@ -1,0 +1,26 @@
+# @lynx-example/animax
+
+Examples showing how to use `<animax-view>` in Lynx.
+
+```bash
+pnpm --filter @lynx-example/animax run dev
+```
+
+## Examples
+
+- `basic`: load a remote animation with autoplay.
+- `basic-json`: render animation data through the `json` prop.
+- `basic-loop`: compare `loop` and `loop-count`.
+- `controls`: build player controls with play, pause, resume, stop, progress, and frame-by-frame seek.
+- `events`: handle `ready`, `firstframe`, `start`, `repeat`, `update`, `fps`, `error`, and `completion`.
+- `events-update`: subscribe to update frames and handle `bindupdate`.
+- `playsegment`: call `playSegment` with integer frame bounds.
+- `methods-query`: call `getDuration`, `getCurrentFrame`, and `isAnimating`.
+- `playback-props`: configure `speed`, `start-frame`, `end-frame`, `auto-reverse`, and `progress`.
+- `firstframe-poster`: hide a poster after `bindfirstframe`.
+- `dynamic-resource-font`: update a font resource by font name.
+- `dynamic-resource-video`: update an alpha video resource by video id.
+- `dynamic-resource-submit`: stage a resource update and submit it.
+- `dynamic-text-layer`: update text value, size, color, and frame-scoped text.
+- `dynamic-layer-property`: update layer visibility and transform properties.
+- `events-tap`: handle layer tap callbacks with `bindtaplayers`.

--- a/examples/animax/lynx.config.ts
+++ b/examples/animax/lynx.config.ts
@@ -1,0 +1,47 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from "@lynx-js/rspeedy";
+
+import { pluginQRCode } from "@lynx-js/qrcode-rsbuild-plugin";
+import { pluginReactLynx } from "@lynx-js/react-rsbuild-plugin";
+import { pluginTypeCheck } from "@rsbuild/plugin-type-check";
+
+export default defineConfig({
+  source: {
+    entry: {
+      basic: "./src/basic/index.tsx",
+      "basic-json": "./src/basic-json/index.tsx",
+      "basic-loop": "./src/basic-loop/index.tsx",
+      "alpha-video-basic": "./src/alpha-video-basic/index.tsx",
+      controls: "./src/controls/index.tsx",
+      "dynamic-resource-font": "./src/dynamic-resource-font/index.tsx",
+      "dynamic-resource-submit": "./src/dynamic-resource-submit/index.tsx",
+      "dynamic-resource-video": "./src/dynamic-resource-video/index.tsx",
+      "dynamic-layer-property": "./src/dynamic-layer-property/index.tsx",
+      "dynamic-layer-wildcard": "./src/dynamic-layer-wildcard/index.tsx",
+      "dynamic-text-layer": "./src/dynamic-text-layer/index.tsx",
+      events: "./src/events/index.tsx",
+      "events-tap": "./src/events-tap/index.tsx",
+      "events-update": "./src/events-update/index.tsx",
+      "firstframe-poster": "./src/firstframe-poster/index.tsx",
+      "methods-query": "./src/methods-query/index.tsx",
+      playsegment: "./src/playsegment/index.tsx",
+      "playback-props": "./src/playback-props/index.tsx",
+    },
+  },
+  plugins: [
+    pluginQRCode(),
+    pluginReactLynx(),
+    pluginTypeCheck(),
+  ],
+  output: {
+    assetPrefix: "https://lynxjs.org/lynx-examples/animax/dist",
+    filename: "[name].[platform].bundle",
+  },
+  environments: {
+    web: {},
+    lynx: {},
+  },
+});

--- a/examples/animax/package.json
+++ b/examples/animax/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@lynx-example/animax",
+  "version": "0.0.0",
+  "description": "Examples showing how to use `<animax-view>` in Lynx",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lynx-family/lynx-examples.git",
+    "directory": "examples/animax"
+  },
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
+  "type": "module",
+  "files": [
+    "dist/",
+    "src/",
+    "lynx.config.ts"
+  ],
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev",
+    "preview": "rspeedy preview"
+  },
+  "dependencies": {
+    "@lynx-js/react": "catalog:"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
+    "@lynx-js/react-rsbuild-plugin": "catalog:",
+    "@lynx-js/rspeedy": "catalog:",
+    "@lynx-js/types": "catalog:",
+    "@types/react": "^18.3.28",
+    "typescript": "~5.9.3"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/examples/animax/src/App.css
+++ b/examples/animax/src/App.css
@@ -1,0 +1,293 @@
+.page {
+  width: 100%;
+  height: 100vh;
+  min-height: 100vh;
+  padding: 14px;
+  box-sizing: border-box;
+  background: #ffffff;
+}
+
+.example {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+}
+
+.dock {
+  width: 100%;
+  height: 72px;
+  padding: 10px;
+  box-sizing: border-box;
+  flex-shrink: 0;
+  overflow: hidden;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+}
+
+.action-dock {
+  display: flex;
+  flex-direction: column;
+  height: 148px;
+}
+
+.surface {
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 0;
+  min-height: 0;
+  margin-top: 12px;
+  flex: 1;
+  overflow: hidden;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #f8fafc;
+}
+
+.animax {
+  width: 100%;
+  height: 100%;
+}
+
+.status-panel {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  overflow: hidden;
+}
+
+.status-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  min-height: 24px;
+  margin-right: 14px;
+  overflow: hidden;
+}
+
+.status-label {
+  margin-right: 6px;
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.status-value {
+  color: #111827;
+  font-size: 13px;
+  font-weight: 700;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.control-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.control-grid.two-up {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.player-dock {
+  height: 156px;
+}
+
+.player-progress {
+  position: relative;
+  width: 100%;
+  height: 22px;
+  margin-top: 10px;
+  overflow: hidden;
+  border-radius: 11px;
+  background: #e9eef5;
+}
+
+.player-progress-track {
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  background: #e9eef5;
+}
+
+.player-progress-fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  border-radius: inherit;
+  background: #2563eb;
+}
+
+.player-progress-text {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 3px;
+  color: #0f172a;
+  font-size: 12px;
+  font-weight: 800;
+  text-align: center;
+}
+
+.player-controls {
+  display: grid;
+  grid-template-columns: 1fr 40px 40px 40px 40px 1fr;
+  gap: 4px;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.icon-button {
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  background: #2563eb;
+}
+
+.icon-button.secondary {
+  background: #eef2ff;
+}
+
+.play-icon {
+  width: 0;
+  height: 0;
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+  border-left: 17px solid #ffffff;
+}
+
+.pause-icon {
+  width: 22px;
+  height: 22px;
+  box-sizing: border-box;
+  border-left: 6px solid #ffffff;
+  border-right: 6px solid #ffffff;
+}
+
+.prev-frame-icon {
+  width: 0;
+  height: 0;
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+  border-left: 1px solid #2563eb;
+  border-right: 17px solid #2563eb;
+}
+
+.next-frame-icon {
+  width: 0;
+  height: 0;
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+  border-left: 17px solid #2563eb;
+  border-right: 1px solid #2563eb;
+}
+
+.stop-icon {
+  width: 18px;
+  height: 18px;
+  border-radius: 2px;
+  background: #2563eb;
+}
+
+.button {
+  align-items: center;
+  justify-content: center;
+  height: 38px;
+  border-radius: 8px;
+  background: #2563eb;
+}
+
+.button.secondary {
+  background: #eef2ff;
+}
+
+.button-text {
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 800;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.button.secondary .button-text {
+  color: #1d4ed8;
+}
+
+.meter {
+  width: 100%;
+  height: 8px;
+  margin-top: 16px;
+  border-radius: 4px;
+  background: #e2e8f0;
+}
+
+.meter-fill {
+  height: 8px;
+  border-radius: 4px;
+  background: #2563eb;
+}
+
+.event-list {
+  display: flex;
+  flex-direction: column;
+  height: 120px;
+  justify-content: center;
+}
+
+.event-item {
+  height: 16px;
+  line-height: 16px;
+  margin-top: 0;
+  color: #111827;
+  font-size: 12px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tap-surface {
+  border-color: #bfdbfe;
+}
+
+.loading-state {
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.loading-text {
+  color: #64748b;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.poster-surface {
+  position: relative;
+}
+
+.poster-layer {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.poster-image {
+  width: 100%;
+  height: 100%;
+}

--- a/examples/animax/src/alpha-video-basic/index.tsx
+++ b/examples/animax/src/alpha-video-basic/index.tsx
@@ -1,0 +1,35 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root } from "@lynx-js/react";
+
+import "../App.css";
+
+import { ALPHA_VIDEO_LOTTIE_SRC } from "../shared/animation.js";
+
+function App() {
+  return (
+    <view className="example">
+      <view className="surface">
+        <animax-view
+          className="animax"
+          src={ALPHA_VIDEO_LOTTIE_SRC}
+          autoplay={true}
+          loop={true}
+          objectfit="contain"
+        />
+      </view>
+    </view>
+  );
+}
+
+root.render(
+  <view className="page">
+    <App />
+  </view>,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/animax/src/basic-json/index.tsx
+++ b/examples/animax/src/basic-json/index.tsx
@@ -1,0 +1,98 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useEffect, useState } from "@lynx-js/react";
+import type * as Lynx from "@lynx-js/types";
+
+import "../App.css";
+
+import type { AnimaXErrorParam, AnimaXReadyParam } from "../intrinsic-element.js";
+import { BASIC_JSON_LOTTIE_SRC, formatFrame, loadLottieJson } from "../shared/animation.js";
+
+type AnimaXReadyEvent = Lynx.BaseEvent<"bindready", AnimaXReadyParam>;
+type AnimaXErrorEvent = Lynx.BaseEvent<"binderror", AnimaXErrorParam>;
+
+function App() {
+  const [json, setJson] = useState("");
+  const [status, setStatus] = useState("loading json");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    loadLottieJson(BASIC_JSON_LOTTIE_SRC)
+      .then((data) => {
+        if (cancelled) {
+          return;
+        }
+
+        setJson(data);
+        setStatus("json loaded");
+      })
+      .catch((error) => {
+        if (cancelled) {
+          return;
+        }
+
+        setStatus("json load error");
+        console.log("[animax] json load error", error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleReady = (e: AnimaXReadyEvent) => {
+    setStatus(`ready: ${formatFrame(e.detail.total)} frames`);
+  };
+
+  const handleError = (e: AnimaXErrorEvent) => {
+    setStatus(`error ${e.detail.code}`);
+    console.log("[animax] load error", e.detail.data);
+  };
+
+  return (
+    <view className="example">
+      <view className="dock status-panel">
+        <view className="status-row">
+          <text className="status-label">Source</text>
+          <text className="status-value">json</text>
+        </view>
+        <view className="status-row">
+          <text className="status-label">Status</text>
+          <text className="status-value">{status}</text>
+        </view>
+      </view>
+      <view className="surface">
+        {json
+          ? (
+            <animax-view
+              className="animax"
+              json={json}
+              autoplay={true}
+              loop={true}
+              objectfit="contain"
+              bindready={handleReady}
+              binderror={handleError}
+            />
+          )
+          : (
+            <view className="loading-state">
+              <text className="loading-text">Loading JSON</text>
+            </view>
+          )}
+      </view>
+    </view>
+  );
+}
+
+root.render(
+  <view className="page">
+    <App />
+  </view>,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/animax/src/basic-loop/index.tsx
+++ b/examples/animax/src/basic-loop/index.tsx
@@ -1,0 +1,68 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from "@lynx-js/react";
+import type * as Lynx from "@lynx-js/types";
+
+import "../App.css";
+
+import type { AnimaXParam } from "../intrinsic-element.js";
+import { BASIC_LOOP_LOTTIE_SRC, formatFrame } from "../shared/animation.js";
+
+type AnimaXRepeatEvent = Lynx.BaseEvent<"bindrepeat", AnimaXParam>;
+type AnimaXCompletionEvent = Lynx.BaseEvent<"bindcompletion", AnimaXParam>;
+
+function App() {
+  const [status, setStatus] = useState("loop-count: 2");
+  const [repeat, setRepeat] = useState(0);
+
+  const handleRepeat = (e: AnimaXRepeatEvent) => {
+    setRepeat(e.detail.loopIndex);
+    setStatus(`repeat: ${e.detail.loopIndex}`);
+  };
+
+  const handleCompletion = (e: AnimaXCompletionEvent) => {
+    setStatus(`complete: ${formatFrame(e.detail.current)}`);
+  };
+
+  return (
+    <view className="example">
+      <view className="dock status-panel">
+        <view className="status-row">
+          <text className="status-label">Loop</text>
+          <text className="status-value">loop-count=2</text>
+        </view>
+        <view className="status-row">
+          <text className="status-label">Repeat</text>
+          <text className="status-value">{repeat}</text>
+        </view>
+        <view className="status-row">
+          <text className="status-label">Status</text>
+          <text className="status-value">{status}</text>
+        </view>
+      </view>
+      <view className="surface">
+        <animax-view
+          className="animax"
+          src={BASIC_LOOP_LOTTIE_SRC}
+          autoplay={true}
+          loop-count={2}
+          objectfit="contain"
+          bindrepeat={handleRepeat}
+          bindcompletion={handleCompletion}
+        />
+      </view>
+    </view>
+  );
+}
+
+root.render(
+  <view className="page">
+    <App />
+  </view>,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/animax/src/basic/index.tsx
+++ b/examples/animax/src/basic/index.tsx
@@ -1,0 +1,34 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root } from "@lynx-js/react";
+
+import "../App.css";
+
+import { BASIC_LOTTIE_SRC } from "../shared/animation.js";
+
+function App() {
+  return (
+    <view className="example">
+      <view className="surface">
+        <animax-view
+          className="animax"
+          src={BASIC_LOTTIE_SRC}
+          autoplay={true}
+          loop={true}
+        />
+      </view>
+    </view>
+  );
+}
+
+root.render(
+  <view className="page">
+    <App />
+  </view>,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/animax/src/controls/index.tsx
+++ b/examples/animax/src/controls/index.tsx
@@ -1,0 +1,263 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from "@lynx-js/react";
+import type * as Lynx from "@lynx-js/types";
+
+import "../App.css";
+
+import type { AnimaXParam, AnimaXReadyParam } from "../intrinsic-element.js";
+import { ANIMAX_VIEW_ID, ceilFrame, CONTROLS_SHAPE_LOTTIE_SRC, formatFrame } from "../shared/animation.js";
+
+type AnimaXReadyEvent = Lynx.BaseEvent<"bindready", AnimaXReadyParam>;
+type AnimaXUpdateEvent = Lynx.BaseEvent<"bindupdate", AnimaXParam>;
+type AnimaXPlaybackEvent = Lynx.BaseEvent<"bindcancel" | "bindcompletion" | "bindstart", AnimaXParam>;
+type AnimaXMethod = "play" | "pause" | "resume" | "stop" | "seek" | "subscribeUpdateEvents";
+
+const PROGRESS_ID = "animax-controls-progress";
+
+function clampFrame(frame: number, total: number) {
+  return Math.max(0, Math.min(frame, total));
+}
+
+function invokeControlMethod(
+  method: AnimaXMethod,
+  params?: Record<string, unknown>,
+  success?: () => void,
+) {
+  lynx
+    .createSelectorQuery()
+    .select(`#${ANIMAX_VIEW_ID}`)
+    .invoke({
+      method,
+      params,
+      success() {
+        success?.();
+      },
+      fail(res) {
+        console.log(`[animax] ${method} fail`, JSON.stringify(res));
+      },
+    })
+    .exec();
+}
+
+function readRect(value: unknown) {
+  const payload = value && typeof value === "object" && "data" in value
+    ? (value as { data?: unknown }).data
+    : value;
+
+  if (!payload || typeof payload !== "object") {
+    return undefined;
+  }
+
+  const rect = payload as { left?: unknown; width?: unknown };
+  if (typeof rect.left !== "number" || typeof rect.width !== "number") {
+    return undefined;
+  }
+
+  return { left: rect.left, width: rect.width };
+}
+
+function App() {
+  const [status, setStatus] = useState("loading");
+  const [isReady, setIsReady] = useState(false);
+  const [canPauseResume, setCanPauseResume] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [totalFrame, setTotalFrame] = useState(0);
+  const [currentFrame, setCurrentFrame] = useState(0);
+
+  const progress = totalFrame > 0 ? (currentFrame / totalFrame) * 100 : 0;
+
+  const handleReady = (e: AnimaXReadyEvent) => {
+    const total = ceilFrame(e.detail.total);
+    setTotalFrame(total);
+    setCurrentFrame(clampFrame(ceilFrame(e.detail.current), total));
+
+    invokeControlMethod(
+      "subscribeUpdateEvents",
+      { frames: Array.from({ length: total + 1 }, (_, index) => index) },
+      () => {
+        setIsReady(true);
+        setStatus(`ready: ${formatFrame(total)} frames`);
+      },
+    );
+  };
+
+  const handleUpdate = (e: AnimaXUpdateEvent) => {
+    setCurrentFrame(clampFrame(ceilFrame(e.detail.current), totalFrame));
+  };
+
+  const handleStart = (e: AnimaXPlaybackEvent) => {
+    setStatus("playing");
+    setIsPlaying(true);
+    setCanPauseResume(true);
+  };
+
+  const handleCompletion = (e: AnimaXPlaybackEvent) => {
+    setStatus("complete");
+    setIsPlaying(false);
+  };
+
+  const handleCancel = () => {
+    setStatus("stopped");
+    setIsPlaying(false);
+    setCanPauseResume(false);
+    setCurrentFrame(0);
+  };
+
+  const seekToFrame = (frame: number) => {
+    if (!isReady) {
+      return;
+    }
+
+    const target = clampFrame(frame, totalFrame);
+    invokeControlMethod("seek", { frame: target }, () => {
+      setCurrentFrame(target);
+      setStatus(`seek: ${formatFrame(target)}`);
+    });
+  };
+
+  const handleTapPlay = () => {
+    if (!isReady) {
+      return;
+    }
+
+    if (!canPauseResume) {
+      invokeControlMethod("play", undefined, () => {
+        setIsPlaying(true);
+        setCanPauseResume(true);
+        setStatus("playing");
+      });
+      return;
+    }
+
+    if (isPlaying) {
+      invokeControlMethod("pause", undefined, () => {
+        setIsPlaying(false);
+        setStatus(`paused: ${formatFrame(currentFrame)}`);
+      });
+      return;
+    }
+
+    invokeControlMethod("resume", undefined, () => {
+      setIsPlaying(true);
+      setStatus("playing");
+    });
+  };
+
+  const handleTapStop = () => {
+    if (!isReady) {
+      return;
+    }
+
+    invokeControlMethod("stop", undefined, handleCancel);
+  };
+
+  const handleTapPrev = () => {
+    seekToFrame(currentFrame > 0 ? currentFrame - 1 : totalFrame);
+  };
+
+  const handleTapNext = () => {
+    seekToFrame(currentFrame < totalFrame ? currentFrame + 1 : 0);
+  };
+
+  const handleTapProgress = (e: Lynx.CommonEvent) => {
+    if (!isReady || totalFrame <= 0) {
+      return;
+    }
+
+    const tapX = typeof e.detail.x === "number" ? e.detail.x : 0;
+
+    lynx
+      .createSelectorQuery()
+      .select(`#${PROGRESS_ID}`)
+      .invoke({
+        method: "boundingClientRect",
+        success(res) {
+          const rect = readRect(res);
+          const width = rect?.width ?? SystemInfo.pixelWidth / SystemInfo.pixelRatio;
+          const left = rect?.left ?? 0;
+          const ratio = width > 0 ? Math.max(0, Math.min((tapX - left) / width, 1)) : 0;
+
+          seekToFrame(Math.round(ratio * totalFrame));
+        },
+        fail(res) {
+          console.log("[animax] progress rect fail", JSON.stringify(res));
+        },
+      })
+      .exec();
+  };
+
+  return (
+    <view className="example">
+      <view className="dock action-dock player-dock">
+        <view className="status-panel">
+          <view className="status-row">
+            <text className="status-label">Status</text>
+            <text className="status-value">{status}</text>
+          </view>
+          <view className="status-row">
+            <text className="status-label">Frame</text>
+            <text className="status-value">
+              {formatFrame(currentFrame)}/{formatFrame(totalFrame)}
+            </text>
+          </view>
+        </view>
+        <view
+          id={PROGRESS_ID}
+          className="player-progress"
+          bindtap={handleTapProgress}
+        >
+          <view className="player-progress-track" />
+          <view
+            className="player-progress-fill"
+            style={{ width: `${progress}%` }}
+          />
+          <text className="player-progress-text">{Math.round(progress)}%</text>
+        </view>
+        <view className="player-controls">
+          <view />
+          <view className="icon-button secondary" bindtap={handleTapPrev}>
+            <view className="prev-frame-icon" />
+          </view>
+          <view className="icon-button" bindtap={handleTapPlay}>
+            {isPlaying && canPauseResume ? <view className="pause-icon" /> : <view className="play-icon" />}
+          </view>
+          <view className="icon-button secondary" bindtap={handleTapNext}>
+            <view className="next-frame-icon" />
+          </view>
+          <view className="icon-button secondary" bindtap={handleTapStop}>
+            <view className="stop-icon" />
+          </view>
+          <view />
+        </view>
+      </view>
+      <view className="surface">
+        <animax-view
+          id={ANIMAX_VIEW_ID}
+          className="animax"
+          src={CONTROLS_SHAPE_LOTTIE_SRC}
+          autoplay={false}
+          loop={true}
+          objectfit="contain"
+          bindready={handleReady}
+          bindupdate={handleUpdate}
+          bindstart={handleStart}
+          bindcancel={handleCancel}
+          bindcompletion={handleCompletion}
+        />
+      </view>
+    </view>
+  );
+}
+
+root.render(
+  <view className="page">
+    <App />
+  </view>,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/animax/src/dynamic-layer-property/index.tsx
+++ b/examples/animax/src/dynamic-layer-property/index.tsx
@@ -1,0 +1,108 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from "@lynx-js/react";
+import type * as Lynx from "@lynx-js/types";
+
+import "../App.css";
+
+import type { AnimaXErrorParam, AnimaXReadyParam } from "../intrinsic-element.js";
+import { DYNAMIC_LAYER_LOTTIE_SRC } from "../shared/animation.js";
+import { createCompositionElementProxy, createValueParam, LayerPropertyType } from "../shared/composition-proxy.js";
+
+type AnimaXReadyEvent = Lynx.BaseEvent<"bindready", AnimaXReadyParam>;
+type AnimaXErrorEvent = Lynx.BaseEvent<"binderror", AnimaXErrorParam>;
+
+function App() {
+  const [status, setStatus] = useState("loading");
+
+  const handleReady = (e: AnimaXReadyEvent) => {
+    const proxy = createCompositionElementProxy(e);
+
+    if (!proxy) {
+      setStatus("animax napi module unavailable");
+      return;
+    }
+
+    const logUpdate = (success?: boolean, errorType?: number) => {
+      console.log("[animax] layer property", success, errorType);
+    };
+
+    proxy.updateLayerProperty(
+      LayerPropertyType.TransformOpacity,
+      "rocket body / red white rounded body",
+      createValueParam(82),
+      logUpdate,
+    );
+    proxy.updateLayerProperty(
+      LayerPropertyType.TransformRotation,
+      "rocket body / red white rounded body",
+      createValueParam(-8),
+      logUpdate,
+    );
+    proxy.updateLayerProperty(
+      LayerPropertyType.TransformPosition,
+      "rocket body / red white rounded body",
+      createValueParam({ x: 0, y: -16 }),
+      logUpdate,
+    );
+    proxy.updateLayerProperty(
+      LayerPropertyType.TransformScale,
+      "window / blue porthole",
+      createValueParam({ x: 1.18, y: 1.18 }),
+      logUpdate,
+    );
+    proxy.updateLayerProperty(
+      LayerPropertyType.Visibility,
+      "sparks / glowing particles",
+      createValueParam(true),
+      logUpdate,
+    );
+
+    setStatus("visibility, opacity, rotation, position, scale updated");
+    proxy.play();
+  };
+
+  const handleError = (e: AnimaXErrorEvent) => {
+    setStatus(`error ${e.detail.code}`);
+    console.log("[animax] load error", e.detail.data);
+  };
+
+  return (
+    <view className="example">
+      <view className="dock status-panel">
+        <view className="status-row">
+          <text className="status-label">Method</text>
+          <text className="status-value">updateLayerProperty</text>
+        </view>
+        <view className="status-row">
+          <text className="status-label">Status</text>
+          <text className="status-value">{status}</text>
+        </view>
+      </view>
+      <view className="surface">
+        <animax-view
+          className="animax"
+          src={DYNAMIC_LAYER_LOTTIE_SRC}
+          autoplay={false}
+          loop={true}
+          objectfit="contain"
+          dynamic-resource={true}
+          bindready={handleReady}
+          binderror={handleError}
+        />
+      </view>
+    </view>
+  );
+}
+
+root.render(
+  <view className="page">
+    <App />
+  </view>,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/animax/src/dynamic-layer-wildcard/index.tsx
+++ b/examples/animax/src/dynamic-layer-wildcard/index.tsx
@@ -1,0 +1,96 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from "@lynx-js/react";
+import type * as Lynx from "@lynx-js/types";
+
+import "../App.css";
+
+import type { AnimaXErrorParam, AnimaXReadyParam } from "../intrinsic-element.js";
+import { DYNAMIC_LAYER_WILDCARD_LOTTIE_SRC } from "../shared/animation.js";
+import { createCompositionElementProxy, createValueParam, LayerPropertyType } from "../shared/composition-proxy.js";
+
+type AnimaXReadyEvent = Lynx.BaseEvent<"bindready", AnimaXReadyParam>;
+type AnimaXErrorEvent = Lynx.BaseEvent<"binderror", AnimaXErrorParam>;
+
+function App() {
+  const [status, setStatus] = useState("loading");
+
+  const handleReady = (e: AnimaXReadyEvent) => {
+    const proxy = createCompositionElementProxy(e);
+
+    if (!proxy) {
+      setStatus("animax napi module unavailable");
+      return;
+    }
+
+    const logUpdate = (success?: boolean, errorType?: number) => {
+      console.log("[animax] wildcard layer property", success, errorType);
+    };
+
+    proxy.updateLayerProperty(
+      LayerPropertyType.TransformScale,
+      "**",
+      createValueParam({ x: 1.08, y: 1.08 }),
+      logUpdate,
+    );
+    proxy.updateLayerProperty(
+      LayerPropertyType.TransformOpacity,
+      "AnimaX modular vector assembly / * / capsule fill",
+      createValueParam(46),
+      logUpdate,
+    );
+    proxy.updateLayerProperty(
+      LayerPropertyType.TransformScale,
+      "AnimaX modular vector assembly / * / dot fill",
+      createValueParam({ x: 1.6, y: 1.6 }),
+      logUpdate,
+    );
+
+    setStatus("wildcard layer updates applied");
+    proxy.play();
+  };
+
+  const handleError = (e: AnimaXErrorEvent) => {
+    setStatus(`error ${e.detail.code}`);
+    console.log("[animax] load error", e.detail.data);
+  };
+
+  return (
+    <view className="example">
+      <view className="dock status-panel">
+        <view className="status-row">
+          <text className="status-label">Method</text>
+          <text className="status-value">wildcard updateLayerProperty</text>
+        </view>
+        <view className="status-row">
+          <text className="status-label">Status</text>
+          <text className="status-value">{status}</text>
+        </view>
+      </view>
+      <view className="surface">
+        <animax-view
+          className="animax"
+          src={DYNAMIC_LAYER_WILDCARD_LOTTIE_SRC}
+          autoplay={false}
+          loop={true}
+          objectfit="contain"
+          dynamic-resource={true}
+          bindready={handleReady}
+          binderror={handleError}
+        />
+      </view>
+    </view>
+  );
+}
+
+root.render(
+  <view className="page">
+    <App />
+  </view>,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/animax/src/dynamic-resource-font/index.tsx
+++ b/examples/animax/src/dynamic-resource-font/index.tsx
@@ -1,0 +1,79 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from "@lynx-js/react";
+import type * as Lynx from "@lynx-js/types";
+
+import "../App.css";
+
+import type { AnimaXErrorParam, AnimaXReadyParam } from "../intrinsic-element.js";
+import { DYNAMIC_FONT_LOTTIE_SRC, DYNAMIC_FONT_REPLACEMENT_URL } from "../shared/animation.js";
+import { createCompositionElementProxy, isPropertyUpdateSuccessful } from "../shared/composition-proxy.js";
+
+type AnimaXReadyEvent = Lynx.BaseEvent<"bindready", AnimaXReadyParam>;
+type AnimaXErrorEvent = Lynx.BaseEvent<"binderror", AnimaXErrorParam>;
+
+function App() {
+  const [status, setStatus] = useState("loading");
+
+  const handleReady = (e: AnimaXReadyEvent) => {
+    const proxy = createCompositionElementProxy(e);
+
+    if (!proxy) {
+      setStatus("animax napi module unavailable");
+      return;
+    }
+
+    proxy.updateFontByName("Arial-BoldMT", DYNAMIC_FONT_REPLACEMENT_URL, (success, errorType) => {
+      console.log("[animax] updateFontByName", success, errorType);
+    });
+
+    proxy.submitResourcePropertiesUpdate((success, errorType) => {
+      setStatus(isPropertyUpdateSuccessful(success) ? "font resource updated" : `submit failed ${errorType}`);
+      proxy.play();
+    });
+  };
+
+  const handleError = (e: AnimaXErrorEvent) => {
+    setStatus(`error ${e.detail.code}`);
+    console.log("[animax] load error", e.detail.data);
+  };
+
+  return (
+    <view className="example">
+      <view className="dock status-panel">
+        <view className="status-row">
+          <text className="status-label">Method</text>
+          <text className="status-value">updateFontByName</text>
+        </view>
+        <view className="status-row">
+          <text className="status-label">Status</text>
+          <text className="status-value">{status}</text>
+        </view>
+      </view>
+      <view className="surface">
+        <animax-view
+          className="animax"
+          src={DYNAMIC_FONT_LOTTIE_SRC}
+          autoplay={false}
+          loop={true}
+          objectfit="contain"
+          dynamic-resource={true}
+          bindready={handleReady}
+          binderror={handleError}
+        />
+      </view>
+    </view>
+  );
+}
+
+root.render(
+  <view className="page">
+    <App />
+  </view>,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/animax/src/dynamic-resource-submit/index.tsx
+++ b/examples/animax/src/dynamic-resource-submit/index.tsx
@@ -1,0 +1,78 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from "@lynx-js/react";
+import type * as Lynx from "@lynx-js/types";
+
+import "../App.css";
+
+import type { AnimaXErrorParam, AnimaXReadyParam } from "../intrinsic-element.js";
+import { DYNAMIC_REPLACEMENT_IMAGE_URL, DYNAMIC_SUBMIT_LOTTIE_SRC } from "../shared/animation.js";
+import { createCompositionElementProxy, isPropertyUpdateSuccessful } from "../shared/composition-proxy.js";
+
+type AnimaXReadyEvent = Lynx.BaseEvent<"bindready", AnimaXReadyParam>;
+type AnimaXErrorEvent = Lynx.BaseEvent<"binderror", AnimaXErrorParam>;
+
+function App() {
+  const [status, setStatus] = useState("loading");
+
+  const handleReady = (e: AnimaXReadyEvent) => {
+    const proxy = createCompositionElementProxy(e);
+
+    if (!proxy) {
+      setStatus("animax napi module unavailable");
+      return;
+    }
+
+    proxy.updateImageById("image_1", DYNAMIC_REPLACEMENT_IMAGE_URL);
+    setStatus("resource staged");
+
+    proxy.submitResourcePropertiesUpdate((success, errorType) => {
+      setStatus(isPropertyUpdateSuccessful(success) ? "resource submitted" : `submit failed ${errorType}`);
+      proxy.play();
+    });
+  };
+
+  const handleError = (e: AnimaXErrorEvent) => {
+    setStatus(`error ${e.detail.code}`);
+    console.log("[animax] load error", e.detail.data);
+  };
+
+  return (
+    <view className="example">
+      <view className="dock status-panel">
+        <view className="status-row">
+          <text className="status-label">Method</text>
+          <text className="status-value">submitResourcePropertiesUpdate</text>
+        </view>
+        <view className="status-row">
+          <text className="status-label">Status</text>
+          <text className="status-value">{status}</text>
+        </view>
+      </view>
+      <view className="surface">
+        <animax-view
+          className="animax"
+          src={DYNAMIC_SUBMIT_LOTTIE_SRC}
+          autoplay={false}
+          loop={true}
+          objectfit="contain"
+          dynamic-resource={true}
+          bindready={handleReady}
+          binderror={handleError}
+        />
+      </view>
+    </view>
+  );
+}
+
+root.render(
+  <view className="page">
+    <App />
+  </view>,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/animax/src/dynamic-resource-video/index.tsx
+++ b/examples/animax/src/dynamic-resource-video/index.tsx
@@ -1,0 +1,79 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from "@lynx-js/react";
+import type * as Lynx from "@lynx-js/types";
+
+import "../App.css";
+
+import type { AnimaXErrorParam, AnimaXReadyParam } from "../intrinsic-element.js";
+import { DYNAMIC_VIDEO_LOTTIE_SRC, DYNAMIC_VIDEO_REPLACEMENT_URL } from "../shared/animation.js";
+import { createCompositionElementProxy, isPropertyUpdateSuccessful } from "../shared/composition-proxy.js";
+
+type AnimaXReadyEvent = Lynx.BaseEvent<"bindready", AnimaXReadyParam>;
+type AnimaXErrorEvent = Lynx.BaseEvent<"binderror", AnimaXErrorParam>;
+
+function App() {
+  const [status, setStatus] = useState("loading");
+
+  const handleReady = (e: AnimaXReadyEvent) => {
+    const proxy = createCompositionElementProxy(e);
+
+    if (!proxy) {
+      setStatus("animax napi module unavailable");
+      return;
+    }
+
+    proxy.updateVideoById("video_0", DYNAMIC_VIDEO_REPLACEMENT_URL, (success, errorType) => {
+      console.log("[animax] updateVideoById", success, errorType);
+    });
+
+    proxy.submitResourcePropertiesUpdate((success, errorType) => {
+      setStatus(isPropertyUpdateSuccessful(success) ? "alpha video resource updated" : `submit failed ${errorType}`);
+      proxy.play();
+    });
+  };
+
+  const handleError = (e: AnimaXErrorEvent) => {
+    setStatus(`error ${e.detail.code}`);
+    console.log("[animax] load error", e.detail.data);
+  };
+
+  return (
+    <view className="example">
+      <view className="dock status-panel">
+        <view className="status-row">
+          <text className="status-label">Method</text>
+          <text className="status-value">updateVideoById</text>
+        </view>
+        <view className="status-row">
+          <text className="status-label">Status</text>
+          <text className="status-value">{status}</text>
+        </view>
+      </view>
+      <view className="surface">
+        <animax-view
+          className="animax"
+          src={DYNAMIC_VIDEO_LOTTIE_SRC}
+          autoplay={false}
+          loop={true}
+          objectfit="contain"
+          dynamic-resource={true}
+          bindready={handleReady}
+          binderror={handleError}
+        />
+      </view>
+    </view>
+  );
+}
+
+root.render(
+  <view className="page">
+    <App />
+  </view>,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/animax/src/dynamic-text-layer/index.tsx
+++ b/examples/animax/src/dynamic-text-layer/index.tsx
@@ -1,0 +1,82 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from "@lynx-js/react";
+import type * as Lynx from "@lynx-js/types";
+
+import "../App.css";
+
+import type { AnimaXErrorParam, AnimaXReadyParam } from "../intrinsic-element.js";
+import { DYNAMIC_TEXT_LOTTIE_SRC } from "../shared/animation.js";
+import { createCompositionElementProxy } from "../shared/composition-proxy.js";
+
+type AnimaXReadyEvent = Lynx.BaseEvent<"bindready", AnimaXReadyParam>;
+type AnimaXErrorEvent = Lynx.BaseEvent<"binderror", AnimaXErrorParam>;
+
+function App() {
+  const [status, setStatus] = useState("loading");
+
+  const handleReady = (e: AnimaXReadyEvent) => {
+    const proxy = createCompositionElementProxy(e);
+
+    if (!proxy) {
+      setStatus("animax napi module unavailable");
+      return;
+    }
+
+    const logUpdate = (success?: boolean, errorType?: number) => {
+      console.log("[animax] text layer property", success, errorType);
+    };
+
+    proxy.updateTextByLayerName("hero headline", "Dynamic text", undefined, logUpdate);
+    proxy.updateTextSizeByLayerName("hero headline", 52, undefined, logUpdate);
+    proxy.updateTextColorByLayerName("hero kicker", "#0f766e", undefined, logUpdate);
+    proxy.updateTextByLayerName("card 01 title", "Updated at frame 0", 0, logUpdate);
+
+    setStatus("text value, size, color updated");
+    proxy.play();
+  };
+
+  const handleError = (e: AnimaXErrorEvent) => {
+    setStatus(`error ${e.detail.code}`);
+    console.log("[animax] load error", e.detail.data);
+  };
+
+  return (
+    <view className="example">
+      <view className="dock status-panel">
+        <view className="status-row">
+          <text className="status-label">Method</text>
+          <text className="status-value">text value / size / color</text>
+        </view>
+        <view className="status-row">
+          <text className="status-label">Status</text>
+          <text className="status-value">{status}</text>
+        </view>
+      </view>
+      <view className="surface">
+        <animax-view
+          className="animax"
+          src={DYNAMIC_TEXT_LOTTIE_SRC}
+          autoplay={false}
+          loop={true}
+          objectfit="contain"
+          dynamic-resource={true}
+          bindready={handleReady}
+          binderror={handleError}
+        />
+      </view>
+    </view>
+  );
+}
+
+root.render(
+  <view className="page">
+    <App />
+  </view>,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/animax/src/events-tap/index.tsx
+++ b/examples/animax/src/events-tap/index.tsx
@@ -1,0 +1,52 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from "@lynx-js/react";
+import type * as Lynx from "@lynx-js/types";
+
+import "../App.css";
+
+import type { AnimaXTapParam } from "../intrinsic-element.js";
+import { EVENTS_TAP_LOTTIE_SRC } from "../shared/animation.js";
+
+type AnimaXTapEvent = Lynx.BaseEvent<"bindtaplayers", AnimaXTapParam>;
+
+function App() {
+  const [layers, setLayers] = useState("tap animation");
+
+  const handleTapLayers = (e: AnimaXTapEvent) => {
+    setLayers(e.detail.layerList.join(", ") || "no layer");
+  };
+
+  return (
+    <view className="example">
+      <view className="dock status-panel">
+        <view className="status-row">
+          <text className="status-label">Layers</text>
+          <text className="status-value">{layers}</text>
+        </view>
+      </view>
+      <view className="surface tap-surface">
+        <animax-view
+          className="animax"
+          src={EVENTS_TAP_LOTTIE_SRC}
+          autoplay={true}
+          loop={true}
+          objectfit="contain"
+          bindtaplayers={handleTapLayers}
+        />
+      </view>
+    </view>
+  );
+}
+
+root.render(
+  <view className="page">
+    <App />
+  </view>,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/animax/src/events-update/index.tsx
+++ b/examples/animax/src/events-update/index.tsx
@@ -1,0 +1,82 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from "@lynx-js/react";
+import type * as Lynx from "@lynx-js/types";
+
+import "../App.css";
+
+import type { AnimaXParam, AnimaXReadyParam } from "../intrinsic-element.js";
+import { ANIMAX_VIEW_ID, ceilFrame, EVENTS_UPDATE_LOTTIE_SRC, formatFrame, invokeAnimaX } from "../shared/animation.js";
+
+type AnimaXReadyEvent = Lynx.BaseEvent<"bindready", AnimaXReadyParam>;
+type AnimaXUpdateEvent = Lynx.BaseEvent<"bindupdate", AnimaXParam>;
+
+function App() {
+  const [status, setStatus] = useState("waiting");
+  const [frame, setFrame] = useState(0);
+
+  const handleReady = (e: AnimaXReadyEvent) => {
+    setStatus(`ready: ${formatFrame(e.detail.total)} frames`);
+    invokeAnimaX("subscribeUpdateEvent", { frame: 30 });
+  };
+
+  const handleUpdate = (e: AnimaXUpdateEvent) => {
+    setFrame(ceilFrame(e.detail.current));
+    setStatus(`update: ${formatFrame(e.detail.current)}`);
+  };
+
+  return (
+    <view className="example">
+      <view className="dock action-dock">
+        <view className="status-panel">
+          <view className="status-row">
+            <text className="status-label">Frame</text>
+            <text className="status-value">{frame}</text>
+          </view>
+          <view className="status-row">
+            <text className="status-label">Status</text>
+            <text className="status-value">{status}</text>
+          </view>
+        </view>
+        <view className="control-grid two-up">
+          <view
+            className="button"
+            bindtap={() => invokeAnimaX("subscribeUpdateEvent", { frame: 60 })}
+          >
+            <text className="button-text">Subscribe 60</text>
+          </view>
+          <view
+            className="button secondary"
+            bindtap={() => invokeAnimaX("subscribeUpdateEvents", { frames: [15, 45, 75] })}
+          >
+            <text className="button-text">Subscribe Many</text>
+          </view>
+        </view>
+      </view>
+      <view className="surface">
+        <animax-view
+          id={ANIMAX_VIEW_ID}
+          className="animax"
+          src={EVENTS_UPDATE_LOTTIE_SRC}
+          autoplay={true}
+          loop={true}
+          objectfit="contain"
+          bindready={handleReady}
+          bindupdate={handleUpdate}
+        />
+      </view>
+    </view>
+  );
+}
+
+root.render(
+  <view className="page">
+    <App />
+  </view>,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/animax/src/events/index.tsx
+++ b/examples/animax/src/events/index.tsx
@@ -1,0 +1,86 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from "@lynx-js/react";
+import type * as Lynx from "@lynx-js/types";
+
+import "../App.css";
+
+import type { AnimaXErrorParam, AnimaXFPSParam, AnimaXParam, AnimaXReadyParam } from "../intrinsic-element.js";
+import { ANIMAX_VIEW_ID, EVENTS_LOTTIE_SRC, formatFrame, invokeAnimaX } from "../shared/animation.js";
+
+type AnimaXReadyEvent = Lynx.BaseEvent<"bindready", AnimaXReadyParam>;
+type AnimaXEvent = Lynx.BaseEvent<
+  "bindstart" | "bindcompletion" | "bindrepeat" | "bindupdate" | "bindfirstframe",
+  AnimaXParam
+>;
+type AnimaXFPSEvent = Lynx.BaseEvent<"bindfps", AnimaXFPSParam>;
+type AnimaXErrorEvent = Lynx.BaseEvent<"binderror", AnimaXErrorParam>;
+
+function App() {
+  const [logs, setLogs] = useState(["waiting"]);
+  const logSlots = [...logs, "", "", "", "", ""].slice(0, 6);
+
+  const pushLog = (label: string, e: AnimaXEvent | AnimaXReadyEvent) => {
+    const item = `${label}: ${formatFrame(e.detail.current)}/${formatFrame(e.detail.total)}`;
+    setLogs((list) => [item, ...list].slice(0, 6));
+  };
+
+  const pushFPSLog = (e: AnimaXFPSEvent) => {
+    const fps = Math.ceil(Number.isFinite(e.detail.fps) ? e.detail.fps : 0);
+    const drop = Math.ceil(Number.isFinite(e.detail.max_drop_rate) ? e.detail.max_drop_rate : 0);
+    setLogs((list) => [`fps: ${fps}, drop ${drop}`, ...list].slice(0, 6));
+  };
+
+  const pushErrorLog = (e: AnimaXErrorEvent) => {
+    setLogs((list) => [`error: ${e.detail.code}`, ...list].slice(0, 6));
+    console.log("[animax] event error", e.detail.data);
+  };
+
+  const handleReady = (e: AnimaXReadyEvent) => {
+    pushLog("ready", e);
+    invokeAnimaX("subscribeUpdateEvents", { frames: [0, 30, 60, 89] });
+  };
+
+  return (
+    <view className="example">
+      <view className="dock event-list">
+        {logSlots.map((log, index) => (
+          <text className="event-item" key={`${index}-${log}`}>
+            {log || " "}
+          </text>
+        ))}
+      </view>
+      <view className="surface">
+        <animax-view
+          id={ANIMAX_VIEW_ID}
+          className="animax"
+          src={EVENTS_LOTTIE_SRC}
+          autoplay={true}
+          loop-count={2}
+          objectfit="contain"
+          fps-event-interval={500}
+          bindready={handleReady}
+          bindfirstframe={(e) => pushLog("firstframe", e)}
+          bindstart={(e) => pushLog("start", e)}
+          bindrepeat={(e) => pushLog("repeat", e)}
+          bindupdate={(e) => pushLog("update", e)}
+          bindfps={pushFPSLog}
+          binderror={pushErrorLog}
+          bindcompletion={(e) => pushLog("completion", e)}
+        />
+      </view>
+    </view>
+  );
+}
+
+root.render(
+  <view className="page">
+    <App />
+  </view>,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/animax/src/firstframe-poster/index.tsx
+++ b/examples/animax/src/firstframe-poster/index.tsx
@@ -1,0 +1,82 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from "@lynx-js/react";
+import type * as Lynx from "@lynx-js/types";
+
+import "../App.css";
+
+import type { AnimaXErrorParam, AnimaXParam, AnimaXReadyParam } from "../intrinsic-element.js";
+import { DYNAMIC_REPLACEMENT_IMAGE_URL, FIRSTFRAME_POSTER_LOTTIE_SRC, formatFrame } from "../shared/animation.js";
+
+type AnimaXReadyEvent = Lynx.BaseEvent<"bindready", AnimaXReadyParam>;
+type AnimaXFirstFrameEvent = Lynx.BaseEvent<"bindfirstframe", AnimaXParam>;
+type AnimaXErrorEvent = Lynx.BaseEvent<"binderror", AnimaXErrorParam>;
+
+function App() {
+  const [status, setStatus] = useState("loading");
+  const [showPoster, setShowPoster] = useState(true);
+
+  const handleReady = (e: AnimaXReadyEvent) => {
+    setStatus(`ready: ${formatFrame(e.detail.total)} frames`);
+  };
+
+  const handleFirstFrame = (e: AnimaXFirstFrameEvent) => {
+    setShowPoster(false);
+    setStatus(`first frame: ${formatFrame(e.detail.current)}`);
+  };
+
+  const handleError = (e: AnimaXErrorEvent) => {
+    setStatus(`error ${e.detail.code}`);
+    console.log("[animax] load error", e.detail.data);
+  };
+
+  return (
+    <view className="example">
+      <view className="dock status-panel">
+        <view className="status-row">
+          <text className="status-label">Poster</text>
+          <text className="status-value">{showPoster ? "visible" : "hidden"}</text>
+        </view>
+        <view className="status-row">
+          <text className="status-label">Status</text>
+          <text className="status-value">{status}</text>
+        </view>
+      </view>
+      <view className="surface poster-surface">
+        <animax-view
+          className="animax"
+          src={FIRSTFRAME_POSTER_LOTTIE_SRC}
+          autoplay={true}
+          loop={true}
+          objectfit="cover"
+          bindready={handleReady}
+          bindfirstframe={handleFirstFrame}
+          binderror={handleError}
+        />
+        {showPoster
+          ? (
+            <view className="poster-layer">
+              <image
+                className="poster-image"
+                src={DYNAMIC_REPLACEMENT_IMAGE_URL}
+                mode="aspectFill"
+              />
+            </view>
+          )
+          : null}
+      </view>
+    </view>
+  );
+}
+
+root.render(
+  <view className="page">
+    <App />
+  </view>,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/animax/src/intrinsic-element.d.ts
+++ b/examples/animax/src/intrinsic-element.d.ts
@@ -1,0 +1,73 @@
+import type * as Lynx from "@lynx-js/types";
+
+export interface AnimaXParam {
+  animationID: string;
+  current: number;
+  total: number;
+  loopIndex: number;
+}
+
+export interface AnimaXReadyParam extends AnimaXParam {
+  elementID: string;
+}
+
+export interface AnimaXFPSParam extends AnimaXParam {
+  fps: number;
+  max_drop_rate: number;
+}
+
+export interface AnimaXErrorParam {
+  code: number;
+  data: string;
+}
+
+export interface AnimaXTapParam extends AnimaXParam {
+  layerList: Array<string>;
+}
+
+type AnimaXObjectFit = "contain" | "cover" | "center" | "fill";
+
+declare module "@lynx-js/types" {
+  interface IntrinsicElements extends Lynx.IntrinsicElements {
+    "animax-view": Lynx.StandardProps & {
+      src?: string;
+      "src-format"?: string;
+      "src-polyfill"?: Record<string, string> | string;
+      json?: string;
+      speed?: number;
+      autoplay?: boolean;
+      "start-frame"?: number;
+      "end-frame"?: number;
+      "auto-reverse"?: boolean;
+      progress?: number;
+      loop?: boolean;
+      "loop-count"?: number;
+      objectfit?: AnimaXObjectFit;
+      "fps-event-interval"?: number;
+      "max-frame-rate"?: number;
+      keeplastframe?: boolean;
+      "ignore-attach-status"?: boolean;
+      "ignore-lynx-lifecycle"?: boolean;
+      "dynamic-resource"?: boolean;
+      "android-enable-screenshot"?: boolean;
+      bindcompletion?: (
+        e: Lynx.BaseEvent<"bindcompletion", AnimaXParam>,
+      ) => void;
+      bindstart?: (e: Lynx.BaseEvent<"bindstart", AnimaXParam>) => void;
+      bindrepeat?: (e: Lynx.BaseEvent<"bindrepeat", AnimaXParam>) => void;
+      bindcancel?: (e: Lynx.BaseEvent<"bindcancel", AnimaXParam>) => void;
+      bindready?: (
+        e: Lynx.BaseEvent<"bindready", AnimaXReadyParam>,
+      ) => void;
+      bindupdate?: (e: Lynx.BaseEvent<"bindupdate", AnimaXParam>) => void;
+      binderror?: (e: Lynx.BaseEvent<"binderror", AnimaXErrorParam>) => void;
+      bindfps?: (e: Lynx.BaseEvent<"bindfps", AnimaXFPSParam>) => void;
+      bindfirstframe?: (
+        e: Lynx.BaseEvent<"bindfirstframe", AnimaXParam>,
+      ) => void;
+      bindtaplayers?: (
+        e: Lynx.BaseEvent<"bindtaplayers", AnimaXTapParam>,
+      ) => void;
+    };
+  }
+}

--- a/examples/animax/src/methods-query/index.tsx
+++ b/examples/animax/src/methods-query/index.tsx
@@ -1,0 +1,159 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from "@lynx-js/react";
+import type * as Lynx from "@lynx-js/types";
+
+import "../App.css";
+
+import type { AnimaXReadyParam } from "../intrinsic-element.js";
+import { ANIMAX_VIEW_ID, ceilFrame, METHODS_QUERY_LOTTIE_SRC } from "../shared/animation.js";
+
+type AnimaXReadyEvent = Lynx.BaseEvent<"bindready", AnimaXReadyParam>;
+type QueryMethod = "getDuration" | "getCurrentFrame" | "isAnimating";
+
+function readPayload(res: unknown) {
+  if (res && typeof res === "object" && "data" in res) {
+    return (res as { data?: unknown }).data;
+  }
+
+  return res;
+}
+
+function readNumber(value: unknown) {
+  if (typeof value === "number") {
+    return value;
+  }
+
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const candidates = [
+      record.current,
+      record.frame,
+      record.duration,
+      record.value,
+    ];
+    return candidates.find((candidate): candidate is number => typeof candidate === "number");
+  }
+
+  return undefined;
+}
+
+function formatQueryResult(method: QueryMethod, res: unknown) {
+  const payload = readPayload(res);
+
+  if (typeof payload === "boolean") {
+    return payload ? "true" : "false";
+  }
+
+  const numeric = readNumber(payload);
+
+  if (typeof numeric === "number") {
+    return `${ceilFrame(numeric)}`;
+  }
+
+  if (payload == null) {
+    return `${method} ok`;
+  }
+
+  return JSON.stringify(payload);
+}
+
+function invokeQuery(method: QueryMethod, onResult: (value: string) => void) {
+  lynx
+    .createSelectorQuery()
+    .select(`#${ANIMAX_VIEW_ID}`)
+    .invoke({
+      method,
+      success(res) {
+        onResult(formatQueryResult(method, res));
+      },
+      fail(res) {
+        console.log(`[animax] ${method} fail`, JSON.stringify(res));
+        onResult(`${method} failed`);
+      },
+    })
+    .exec();
+}
+
+function App() {
+  const [status, setStatus] = useState("loading");
+  const [duration, setDuration] = useState("-");
+  const [frame, setFrame] = useState("-");
+  const [animating, setAnimating] = useState("-");
+
+  const handleReady = (e: AnimaXReadyEvent) => {
+    setStatus(`ready: ${ceilFrame(e.detail.total)} frames`);
+    invokeQuery("getDuration", setDuration);
+  };
+
+  const queryDuration = () => {
+    invokeQuery("getDuration", setDuration);
+  };
+
+  const queryCurrentFrame = () => {
+    invokeQuery("getCurrentFrame", setFrame);
+  };
+
+  const queryAnimating = () => {
+    invokeQuery("isAnimating", setAnimating);
+  };
+
+  return (
+    <view className="example">
+      <view className="dock action-dock">
+        <view className="status-panel">
+          <view className="status-row">
+            <text className="status-label">Status</text>
+            <text className="status-value">{status}</text>
+          </view>
+          <view className="status-row">
+            <text className="status-label">Duration</text>
+            <text className="status-value">{duration}</text>
+          </view>
+          <view className="status-row">
+            <text className="status-label">Frame</text>
+            <text className="status-value">{frame}</text>
+          </view>
+          <view className="status-row">
+            <text className="status-label">Animating</text>
+            <text className="status-value">{animating}</text>
+          </view>
+        </view>
+        <view className="control-grid">
+          <view className="button" bindtap={queryDuration}>
+            <text className="button-text">Duration</text>
+          </view>
+          <view className="button secondary" bindtap={queryCurrentFrame}>
+            <text className="button-text">Frame</text>
+          </view>
+          <view className="button secondary" bindtap={queryAnimating}>
+            <text className="button-text">Animating</text>
+          </view>
+        </view>
+      </view>
+      <view className="surface">
+        <animax-view
+          id={ANIMAX_VIEW_ID}
+          className="animax"
+          src={METHODS_QUERY_LOTTIE_SRC}
+          autoplay={true}
+          loop={true}
+          objectfit="contain"
+          bindready={handleReady}
+        />
+      </view>
+    </view>
+  );
+}
+
+root.render(
+  <view className="page">
+    <App />
+  </view>,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/animax/src/playback-props/index.tsx
+++ b/examples/animax/src/playback-props/index.tsx
@@ -1,0 +1,110 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from "@lynx-js/react";
+import type * as Lynx from "@lynx-js/types";
+
+import "../App.css";
+
+import type { AnimaXParam, AnimaXReadyParam } from "../intrinsic-element.js";
+import { ceilFrame, PLAYBACK_PROPS_LOTTIE_SRC } from "../shared/animation.js";
+
+type AnimaXReadyEvent = Lynx.BaseEvent<"bindready", AnimaXReadyParam>;
+type AnimaXEvent = Lynx.BaseEvent<"bindrepeat" | "bindcompletion", AnimaXParam>;
+
+function App() {
+  const [status, setStatus] = useState("loading");
+  const [speed, setSpeed] = useState(1.25);
+  const [progress, setProgress] = useState(0.2);
+
+  const handleReady = (e: AnimaXReadyEvent) => {
+    setStatus(`frames 24-${ceilFrame(e.detail.total) - 24}`);
+  };
+
+  const handleRepeat = (e: AnimaXEvent) => {
+    setStatus(`repeat ${e.detail.loopIndex}`);
+  };
+
+  const handleCompletion = () => {
+    setStatus("completion");
+  };
+
+  const setSlow = () => {
+    setSpeed(0.6);
+  };
+
+  const setFast = () => {
+    setSpeed(1.6);
+  };
+
+  const setEarlyProgress = () => {
+    setProgress(0.2);
+  };
+
+  const setLateProgress = () => {
+    setProgress(0.72);
+  };
+
+  return (
+    <view className="example">
+      <view className="dock action-dock">
+        <view className="status-panel">
+          <view className="status-row">
+            <text className="status-label">Speed</text>
+            <text className="status-value">{speed}</text>
+          </view>
+          <view className="status-row">
+            <text className="status-label">Progress</text>
+            <text className="status-value">{Math.ceil(progress * 100)}%</text>
+          </view>
+          <view className="status-row">
+            <text className="status-label">Status</text>
+            <text className="status-value">{status}</text>
+          </view>
+        </view>
+        <view className="control-grid two-up">
+          <view className="button" bindtap={setSlow}>
+            <text className="button-text">Speed 0.6</text>
+          </view>
+          <view className="button secondary" bindtap={setFast}>
+            <text className="button-text">Speed 1.6</text>
+          </view>
+          <view className="button secondary" bindtap={setEarlyProgress}>
+            <text className="button-text">Progress 20%</text>
+          </view>
+          <view className="button secondary" bindtap={setLateProgress}>
+            <text className="button-text">Progress 72%</text>
+          </view>
+        </view>
+      </view>
+      <view className="surface">
+        <animax-view
+          className="animax"
+          src={PLAYBACK_PROPS_LOTTIE_SRC}
+          autoplay={true}
+          start-frame={24}
+          end-frame={144}
+          auto-reverse={true}
+          speed={speed}
+          progress={progress}
+          loop-count={2}
+          objectfit="contain"
+          bindready={handleReady}
+          bindrepeat={handleRepeat}
+          bindcompletion={handleCompletion}
+        />
+      </view>
+    </view>
+  );
+}
+
+root.render(
+  <view className="page">
+    <App />
+  </view>,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/animax/src/playsegment/index.tsx
+++ b/examples/animax/src/playsegment/index.tsx
@@ -1,0 +1,71 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from "@lynx-js/react";
+import type * as Lynx from "@lynx-js/types";
+
+import "../App.css";
+
+import type { AnimaXParam } from "../intrinsic-element.js";
+import { ANIMAX_VIEW_ID, formatFrame, invokeAnimaX, PLAY_SEGMENT_LOTTIE_SRC } from "../shared/animation.js";
+
+type AnimaXEvent = Lynx.BaseEvent<"bindstart" | "bindcompletion", AnimaXParam>;
+
+function App() {
+  const [status, setStatus] = useState("ready");
+
+  const updateStatus = (label: string) => (e: AnimaXEvent) => {
+    setStatus(`${label}: ${formatFrame(e.detail.current)}`);
+  };
+
+  return (
+    <view className="example">
+      <view className="dock action-dock">
+        <view className="status-panel">
+          <view className="status-row">
+            <text className="status-label">Segment</text>
+            <text className="status-value">15-75</text>
+          </view>
+          <view className="status-row">
+            <text className="status-label">Status</text>
+            <text className="status-value">{status}</text>
+          </view>
+        </view>
+        <view className="control-grid two-up">
+          <view
+            className="button"
+            bindtap={() => invokeAnimaX("playSegment", { startFrame: 15, endFrame: 75 })}
+          >
+            <text className="button-text">Play Segment</text>
+          </view>
+          <view className="button secondary" bindtap={() => invokeAnimaX("stop")}>
+            <text className="button-text">Stop</text>
+          </view>
+        </view>
+      </view>
+      <view className="surface">
+        <animax-view
+          id={ANIMAX_VIEW_ID}
+          className="animax"
+          src={PLAY_SEGMENT_LOTTIE_SRC}
+          autoplay={false}
+          loop={true}
+          objectfit="contain"
+          bindstart={updateStatus("start")}
+          bindcompletion={updateStatus("complete")}
+        />
+      </view>
+    </view>
+  );
+}
+
+root.render(
+  <view className="page">
+    <App />
+  </view>,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/animax/src/rspeedy-env.d.ts
+++ b/examples/animax/src/rspeedy-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@lynx-js/rspeedy/client" />

--- a/examples/animax/src/shared/animation.ts
+++ b/examples/animax/src/shared/animation.ts
@@ -1,0 +1,106 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export const ANIMAX_VIEW_ID = "animax-view";
+
+export const ANIMAX_SHOWCASE_BASE = "https://tosv-sg.tiktok-row.org/obj/lynx-artifacts-oss-sg/animax/showcase_url";
+
+export const BASIC_LOTTIE_SRC = `${ANIMAX_SHOWCASE_BASE}/logo.json`;
+
+export const CONTROLS_SHAPE_LOTTIE_SRC = BASIC_LOTTIE_SRC;
+
+export const BASIC_JSON_LOTTIE_SRC = `${ANIMAX_SHOWCASE_BASE}/case_json/animation.json`;
+
+export const BASIC_LOOP_LOTTIE_SRC = `${ANIMAX_SHOWCASE_BASE}/case_shape_02/animation.json`;
+
+export const ALPHA_VIDEO_LOTTIE_SRC = `${ANIMAX_SHOWCASE_BASE}/case_alpha_video/animation.json`;
+
+export const CONTROLS_LOTTIE_SRC = `${ANIMAX_SHOWCASE_BASE}/case_alpha_video/animation.json`;
+
+export const DYNAMIC_FONT_LOTTIE_SRC = `${ANIMAX_SHOWCASE_BASE}/case_alpha_video_mixed/animation.json`;
+
+export const DYNAMIC_VIDEO_LOTTIE_SRC = `${ANIMAX_SHOWCASE_BASE}/case_alpha_video/animation.json`;
+
+export const DYNAMIC_SUBMIT_LOTTIE_SRC = `${ANIMAX_SHOWCASE_BASE}/case_text/animation.json`;
+
+export const DYNAMIC_TEXT_LOTTIE_SRC = `${ANIMAX_SHOWCASE_BASE}/case_text_03/animation.json`;
+
+export const DYNAMIC_LAYER_LOTTIE_SRC = `${ANIMAX_SHOWCASE_BASE}/case_shape/animation.json`;
+
+export const DYNAMIC_LAYER_WILDCARD_LOTTIE_SRC = `${ANIMAX_SHOWCASE_BASE}/case_shape_02/animation.json`;
+
+export const EVENTS_LOTTIE_SRC = `${ANIMAX_SHOWCASE_BASE}/case_text_02/animation.json`;
+
+export const EVENTS_TAP_LOTTIE_SRC = `${ANIMAX_SHOWCASE_BASE}/case_image/animation.json`;
+
+export const EVENTS_UPDATE_LOTTIE_SRC = `${ANIMAX_SHOWCASE_BASE}/case_alpha_video_mixed/animation.json`;
+
+export const PLAY_SEGMENT_LOTTIE_SRC = `${ANIMAX_SHOWCASE_BASE}/case_text_03/animation.json`;
+
+export const METHODS_QUERY_LOTTIE_SRC = `${ANIMAX_SHOWCASE_BASE}/case_text/animation.json`;
+
+export const PLAYBACK_PROPS_LOTTIE_SRC = `${ANIMAX_SHOWCASE_BASE}/case_shape_02/animation.json`;
+
+export const FIRSTFRAME_POSTER_LOTTIE_SRC = `${ANIMAX_SHOWCASE_BASE}/case_text_02/animation.json`;
+
+export const DYNAMIC_REPLACEMENT_IMAGE_URL = `${ANIMAX_SHOWCASE_BASE}/case_image/images/lifestyle_04-8b37a7fa.png`;
+
+export const DYNAMIC_FONT_REPLACEMENT_URL = `${ANIMAX_SHOWCASE_BASE}/case_alpha_video_mixed/fonts/Arial-722a8714.ttf`;
+
+export const DYNAMIC_VIDEO_REPLACEMENT_URL =
+  `${ANIMAX_SHOWCASE_BASE}/case_alpha_video_mixed/videos/video_0_animax_logo_80pct_alpha_sbs-56900674.mp4`;
+
+export type AnimaXMethod =
+  | "play"
+  | "pause"
+  | "resume"
+  | "stop"
+  | "seek"
+  | "playSegment"
+  | "subscribeUpdateEvent"
+  | "subscribeUpdateEvents"
+  | "unsubscribeUpdateEvent"
+  | "unsubscribeUpdateEvents"
+  | "getDuration"
+  | "getCurrentFrame"
+  | "isAnimating";
+
+export function invokeAnimaX(
+  method: AnimaXMethod,
+  params?: Record<string, unknown>,
+  targetId = ANIMAX_VIEW_ID,
+) {
+  lynx
+    .createSelectorQuery()
+    .select(`#${targetId}`)
+    .invoke({
+      method,
+      params,
+      success(res) {
+        console.log(`[animax] ${method} success`, JSON.stringify(res));
+      },
+      fail(res) {
+        console.log(`[animax] ${method} fail`, JSON.stringify(res));
+      },
+    })
+    .exec();
+}
+
+export function ceilFrame(value: number) {
+  return Math.ceil(Number.isFinite(value) ? value : 0);
+}
+
+export function formatFrame(value: number) {
+  return `${ceilFrame(value)}`;
+}
+
+export async function loadLottieJson(url: string) {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to load lottie json: ${response.status}`);
+  }
+
+  return response.text();
+}

--- a/examples/animax/src/shared/composition-proxy.ts
+++ b/examples/animax/src/shared/composition-proxy.ts
@@ -1,0 +1,295 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type * as Lynx from "@lynx-js/types";
+
+import type { AnimaXReadyParam } from "../intrinsic-element.js";
+
+export type AnimaXReadyEvent = Lynx.BaseEvent<"bindready", AnimaXReadyParam>;
+
+export enum LayerPropertyType {
+  Visibility = 1,
+  TransformOpacity = 2,
+  TransformAnchor = 3,
+  TransformPosition = 4,
+  TransformScale = 5,
+  TransformRotation = 6,
+  TextValue = 101,
+  TextSize = 102,
+  TextColor = 103,
+}
+
+export enum ResourcePropertyType {
+  ImageDirName = 1,
+  ImageFileName = 2,
+  FontPath = 104,
+  VideoDirName = 201,
+  VideoFileName = 202,
+}
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface ValueParam {
+  stringValue?: string;
+  pointX?: number;
+  pointY?: number;
+  doubleValue?: number;
+  boolValue?: boolean;
+  frameIndex: number;
+}
+
+export type DynamicValue = string | number | boolean | Point;
+export type PropertyCallback = (success?: boolean, errorType?: number) => void;
+
+export function isPropertyUpdateSuccessful(success?: boolean) {
+  return success !== false;
+}
+
+interface NativeCompositionElement {
+  play(): void;
+  updateLayerProperty(
+    type: LayerPropertyType,
+    layerName: string,
+    value: ValueParam,
+    callback: PropertyCallback,
+  ): void;
+  setResourceProperty(
+    type: ResourcePropertyType,
+    resourceId: string,
+    value: ValueParam,
+    callback: PropertyCallback,
+  ): void;
+  submitResourcePropertiesUpdate(callback: PropertyCallback): void;
+}
+
+interface AnimaXModule {
+  CompositionElement: new(elementID: string) => NativeCompositionElement;
+}
+
+const ALL_FRAME = -1;
+const noop: PropertyCallback = () => {};
+
+export function createValueParam(value: DynamicValue, targetFrame = ALL_FRAME): ValueParam {
+  if (typeof value === "object") {
+    return {
+      pointX: value.x,
+      pointY: value.y,
+      frameIndex: targetFrame,
+    };
+  }
+
+  if (typeof value === "string") {
+    return {
+      stringValue: value,
+      frameIndex: targetFrame,
+    };
+  }
+
+  if (typeof value === "number") {
+    return {
+      doubleValue: value,
+      frameIndex: targetFrame,
+    };
+  }
+
+  return {
+    boolValue: value,
+    frameIndex: targetFrame,
+  };
+}
+
+export function formatColorString(color: string) {
+  if (!/^(#|0x)([0-9a-fA-F]{2}){3,4}$/.test(color)) {
+    return null;
+  }
+
+  return color.slice(color.startsWith("#") ? 1 : 2);
+}
+
+function autoAdaptValueParam(type: LayerPropertyType, value: ValueParam) {
+  if (
+    type !== LayerPropertyType.TransformAnchor
+    && type !== LayerPropertyType.TransformPosition
+    && type !== LayerPropertyType.TextSize
+  ) {
+    return;
+  }
+
+  const pixelRatio = (globalThis as { SystemInfo?: { pixelRatio?: number } }).SystemInfo?.pixelRatio;
+  const density = typeof pixelRatio === "number" ? pixelRatio : 1;
+
+  if (density === 1) {
+    return;
+  }
+
+  if (typeof value.pointX === "number" && typeof value.pointY === "number") {
+    value.pointX *= density;
+    value.pointY *= density;
+  } else if (typeof value.doubleValue === "number") {
+    value.doubleValue *= density;
+  }
+}
+
+function loadAnimaXModule() {
+  "background only";
+
+  const moduleLoader = (lynx as unknown as {
+    getModuleLoader?: () => { load(moduleName: "animax"): AnimaXModule };
+  }).getModuleLoader?.();
+  const loadedModule = moduleLoader?.load("animax");
+
+  if (loadedModule) {
+    return loadedModule;
+  }
+
+  const app = (lynx as unknown as {
+    getApp?: () => { _nativeApp?: { id?: string | number }; nativeAppId?: string | number };
+  }).getApp?.();
+  const runtimeId = app?._nativeApp?.id ?? app?.nativeAppId;
+  const loaders = globalThis as unknown as Record<
+    string,
+    { load(moduleName: "animax"): AnimaXModule } | undefined
+  >;
+  const loader = runtimeId == null
+    ? undefined
+    : loaders[`napiLoaderOnRT${runtimeId}`];
+
+  return loader?.load("animax");
+}
+
+export class CompositionElementProxy {
+  private readonly element: NativeCompositionElement;
+
+  constructor(element: NativeCompositionElement) {
+    this.element = element;
+  }
+
+  updateTextByLayerName(
+    layerName: string,
+    newText: string,
+    targetFrame?: number,
+    callback?: PropertyCallback,
+  ) {
+    this.updateLayerProperty(
+      LayerPropertyType.TextValue,
+      layerName,
+      createValueParam(newText, targetFrame),
+      callback,
+    );
+  }
+
+  updateTextSizeByLayerName(
+    layerName: string,
+    textSize: number,
+    targetFrame?: number,
+    callback?: PropertyCallback,
+  ) {
+    this.updateLayerProperty(
+      LayerPropertyType.TextSize,
+      layerName,
+      createValueParam(textSize, targetFrame),
+      callback,
+    );
+  }
+
+  updateTextColorByLayerName(
+    layerName: string,
+    textColor: string,
+    targetFrame?: number,
+    callback?: PropertyCallback,
+  ) {
+    const color = formatColorString(textColor);
+
+    if (color == null) {
+      return false;
+    }
+
+    this.updateLayerProperty(
+      LayerPropertyType.TextColor,
+      layerName,
+      createValueParam(color, targetFrame),
+      callback,
+    );
+    return true;
+  }
+
+  updateImageById(imageId: string, newImageUrl: string, callback?: PropertyCallback) {
+    this.setResourceProperty(
+      ResourcePropertyType.ImageDirName,
+      imageId,
+      createValueParam(""),
+      callback,
+    );
+    this.setResourceProperty(
+      ResourcePropertyType.ImageFileName,
+      imageId,
+      createValueParam(newImageUrl),
+      callback,
+    );
+  }
+
+  updateVideoById(videoId: string, newVideoUrl: string, callback?: PropertyCallback) {
+    this.setResourceProperty(
+      ResourcePropertyType.VideoDirName,
+      videoId,
+      createValueParam(""),
+      callback,
+    );
+    this.setResourceProperty(
+      ResourcePropertyType.VideoFileName,
+      videoId,
+      createValueParam(newVideoUrl),
+      callback,
+    );
+  }
+
+  updateFontByName(fontName: string, newFontPath: string, callback?: PropertyCallback) {
+    this.setResourceProperty(
+      ResourcePropertyType.FontPath,
+      fontName,
+      createValueParam(newFontPath),
+      callback,
+    );
+  }
+
+  updateLayerProperty(
+    type: LayerPropertyType,
+    layerName: string,
+    value: ValueParam,
+    callback?: PropertyCallback,
+  ) {
+    autoAdaptValueParam(type, value);
+    this.element.updateLayerProperty(type, layerName, value, callback ?? noop);
+  }
+
+  setResourceProperty(
+    type: ResourcePropertyType,
+    resourceId: string,
+    value: ValueParam,
+    callback?: PropertyCallback,
+  ) {
+    this.element.setResourceProperty(type, resourceId, value, callback ?? noop);
+  }
+
+  submitResourcePropertiesUpdate(callback?: PropertyCallback) {
+    this.element.submitResourcePropertiesUpdate(callback ?? noop);
+  }
+
+  play() {
+    this.element.play();
+  }
+}
+
+export function createCompositionElementProxy(e: AnimaXReadyEvent) {
+  const animax = loadAnimaXModule();
+
+  if (!animax) {
+    return undefined;
+  }
+
+  return new CompositionElementProxy(new animax.CompositionElement(e.detail.elementID));
+}

--- a/examples/animax/tsconfig.json
+++ b/examples/animax/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "@lynx-js/react",
+
+    "module": "node16",
+    "moduleResolution": "node16",
+
+    "strict": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+
+    "paths": {
+    },
+  },
+  "exclude": ["dist/"],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,6 +304,31 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
 
+  examples/animax:
+    dependencies:
+      '@lynx-js/react':
+        specifier: 'catalog:'
+        version: 0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28)
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.4.7
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.16.3(@lynx-js/react@0.121.1(@lynx-js/types@4.0.0)(@types/react@18.3.28))(tslib@2.8.1)(webpack@5.101.3)
+      '@lynx-js/rspeedy':
+        specifier: 'catalog:'
+        version: 0.14.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.1(@swc/helpers@0.5.21))(typescript@5.9.3)(webpack@5.101.3)
+      '@lynx-js/types':
+        specifier: 4.0.0
+        version: 4.0.0
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+
   examples/blur-view:
     dependencies:
       '@lynx-js/react':


### PR DESCRIPTION
## Summary

Add a new `@lynx-example/animax` example package covering core `<animax-view>` usage patterns: src playback, json playback, loop playback, controls, events, update subscriptions, tap layer events, play segment, and dynamic text/image resource updates.

The examples use the standard Rspeedy ReactLynx scaffold and CDN-hosted animation resources. Layouts reserve fixed control/log space so animation view sizing stays stable while events and status values update.

## Checks

- `pnpm dprint check README.md pnpm-lock.yaml .changeset/fair-lions-animate.md examples/animax`
- `pnpm meta-updater --test`
- `pnpm --filter @lynx-example/animax run build`
