### PR TITLE
chore: publish animax example

### DIFF
--- a/examples/animax/package.json
+++ b/examples/animax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lynx-example/animax",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Examples showing how to use `<animax-view>` in Lynx",
   "repository": {
     "type": "git",
@@ -33,5 +33,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary

- Bump `@lynx-example/animax` to `0.0.1`.
- Set `publishConfig.access` to `public` so the example package can be published publicly.

## Validation

- `corepack pnpm dprint check examples/animax/package.json`
- `corepack pnpm meta-updater --test`
- `corepack pnpm changeset status --verbose --since origin/main`
- `corepack pnpm --filter @lynx-example/animax run build`
