### PR TITLE
chore: publish vanilla example

### DIFF
--- a/.changeset/vanilla-element-papi-helpers.md
+++ b/.changeset/vanilla-element-papi-helpers.md
@@ -1,5 +1,0 @@
----
-"@lynx-example/vanilla": patch
----
-
-Refactor the vanilla Element PAPI example with shared main-thread/background helpers, Lynx Engine 3.5 targeting, and main-thread event forwarding.

--- a/examples/vanilla/package.json
+++ b/examples/vanilla/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@lynx-example/vanilla",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.1.0",
   "description": "An example of building Lynx apps with Element PAPI",
   "repository": {
     "type": "git",
@@ -33,5 +32,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary

- prepare `@lynx-example/vanilla` for public publishing at version `0.1.0`
- remove the obsolete vanilla patch changeset so the initial release is not bumped to `0.1.1`

## Why

The vanilla example was marked private and had no public publish configuration, so it could not be released as a public package. The existing patch changeset would conflict with the explicit `0.1.0` publishing baseline.

## Impact

`@lynx-example/vanilla` can be published publicly at `0.1.0`. There are no runtime behavior changes.

## Validation

- `pnpm meta-updater --test`
- `pnpm dprint check`
- `pnpm changeset status --verbose --since origin/main`
- `pnpm --filter @lynx-example/vanilla run build`
