### PR TITLE
fix(react-devtool): upgrade @lynx-js/preact-devtools to fix production build

### DIFF
--- a/.changeset/fix-preact-devtools-production.md
+++ b/.changeset/fix-preact-devtools-production.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/react-devtool": patch
+---
+
+Upgrade `@lynx-js/preact-devtools` to `5.0.1-20260716151326-abdb87c` which no longer gates setup behind `__DEV__`, fixing production builds with `REACT_DEVTOOL=true`.

--- a/examples/react-devtool/package.json
+++ b/examples/react-devtool/package.json
@@ -24,7 +24,7 @@
     "@lynx-example/lynx-ui-gallery": "workspace:*",
     "@lynx-js/luna-styles": "0.1.0",
     "@lynx-js/lynx-ui": "3.133.1",
-    "@lynx-js/preact-devtools": "5.0.1-20260525112551-dfe2d03",
+    "@lynx-js/preact-devtools": "5.0.1-20260716151326-abdb87c",
     "@lynx-js/react": "catalog:"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1192,8 +1192,8 @@ importers:
         specifier: 3.133.1
         version: 3.133.1(@lynx-js/react@0.123.0(@lynx-js/types@4.0.0)(@types/react@18.3.28))(@lynx-js/types@4.0.0)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260525112551-dfe2d03
-        version: 5.0.1-20260525112551-dfe2d03
+        specifier: 5.0.1-20260716151326-abdb87c
+        version: 5.0.1-20260716151326-abdb87c
       '@lynx-js/react':
         specifier: 'catalog:'
         version: 0.123.0(@lynx-js/types@4.0.0)(@types/react@18.3.28)
@@ -2750,8 +2750,8 @@ packages:
       '@lynx-js/types':
         optional: true
 
-  '@lynx-js/preact-devtools@5.0.1-20260525112551-dfe2d03':
-    resolution: {integrity: sha512-q6zlNTtYIA8jCGmnGE6umf6/caTiMa/tkjk+omaBX3Uj4JyIDuV/oWRi/UPDYS9VodBe4Fl6kWsZBQNAK9f9gQ==}
+  '@lynx-js/preact-devtools@5.0.1-20260716151326-abdb87c':
+    resolution: {integrity: sha512-a0k5zLVykaSx2SwoNhyHYkj94VI/Qx5irv2Xf9leJP4Mcb/7uP2g/bJLpijRPrfeLCDvKy5t6WmEWSucKZ7cug==}
 
   '@lynx-js/qrcode-rsbuild-plugin@0.6.0':
     resolution: {integrity: sha512-AjRhjQH5xEJKo5VUIIsjdk6zc6qXMf4QsGvKTDuwBjuGr01sDkLLpAt+wbu9GCJvDlGA7ygNTEsxaPJPYHPmIw==}
@@ -9358,7 +9358,7 @@ snapshots:
       - react
       - react-dom
 
-  '@lynx-js/preact-devtools@5.0.1-20260525112551-dfe2d03':
+  '@lynx-js/preact-devtools@5.0.1-20260716151326-abdb87c':
     dependencies:
       errorstacks: 2.4.2
       htm: 3.1.1


### PR DESCRIPTION
## Summary

Upgrades `@lynx-js/preact-devtools` from `5.0.1-20260525112551-dfe2d03` to `5.0.1-20260716151326-abdb87c`.

## Problem

The `@lynx-example/react-devtool@0.2.2` release (commit d0902fc) replaced the old `REACT_DEV=true` build script + patched plugins with the new native `REACT_DEVTOOL=true` support in rspeedy 0.16.0. However, the old `@lynx-js/preact-devtools` version still guarded its entry with `if (__DEV__) { ... }`:

```js
// Old: lib/react-lynx/index.js
if (__DEV__ && process.env.NODE_ENV !== "test") {
    require("./setup").setupReactLynx();
}
```

Since `__DEV__` is `false` in production builds, the entire devtools initialization was dead-code-eliminated — even though `REACT_DEVTOOL=true` correctly prevented the module from being aliased away.

This broke all downstream consumers relying on the published bundle containing devtools (e.g. lynx-use embedded-lynx E2E tests).

## Fix

The latest `@lynx-js/preact-devtools` (`5.0.1-20260716151326-abdb87c`) removes the `__DEV__` guard entirely:

```js
// New: lib/react-lynx/index.js
if (process.env.NODE_ENV !== "test") {
    // setup runs unconditionally — the module being bundled IS the opt-in
    ...
}
```

## Verification

Local build confirms devtools code is present in the output bundle:
- Before: 753KB, 0 devtools symbols
- After: 851KB, `setupReactLynx`(6), `DevtoolsCtx`(33), `preact-devtools-to-client`(1), `operation_v2`(1)