### PR TITLE
(Do NOT merge, this is a test MR) feat: add creator card patterns example

### DIFF
--- a/examples/creator-card-patterns/CHANGELOG.md
+++ b/examples/creator-card-patterns/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @lynx-example/creator-card-patterns
+
+## 0.0.0
+
+### Patch Changes
+
+- Initial creator card patterns example.

--- a/examples/creator-card-patterns/README.md
+++ b/examples/creator-card-patterns/README.md
@@ -1,0 +1,16 @@
+# Creator Card Patterns
+
+This example demonstrates three focused Lynx UI capabilities with deterministic mock data:
+
+- adaptive text that reduces font size when the rendered text is ellipsized;
+- compact media cards with cover imagery, metadata, author affordance, and tap feedback;
+- dismissible information cards with basic, action, and image variants.
+
+Run it with:
+
+```bash
+pnpm --filter @lynx-example/creator-card-patterns run dev
+pnpm --filter @lynx-example/creator-card-patterns run build
+```
+
+The example intentionally replaces app navigation, analytics, private design tokens, and live data with local callbacks, public Lynx elements, and stable mocks.

--- a/examples/creator-card-patterns/lynx.config.ts
+++ b/examples/creator-card-patterns/lynx.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "@lynx-js/rspeedy";
+
+import { pluginQRCode } from "@lynx-js/qrcode-rsbuild-plugin";
+import { pluginReactLynx } from "@lynx-js/react-rsbuild-plugin";
+import { pluginTypeCheck } from "@rsbuild/plugin-type-check";
+
+export default defineConfig({
+  plugins: [
+    pluginQRCode(),
+    pluginReactLynx(),
+    pluginTypeCheck(),
+  ],
+  output: {
+    dataUriLimit: Infinity,
+    filename: "[name].[platform].bundle",
+  },
+  environments: {
+    web: {},
+    lynx: {},
+  },
+});

--- a/examples/creator-card-patterns/package.json
+++ b/examples/creator-card-patterns/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@lynx-example/creator-card-patterns",
+  "version": "0.0.0",
+  "description": "An example showing adaptive text, media cards, and dismissible information cards in Lynx",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lynx-family/lynx-examples.git",
+    "directory": "examples/creator-card-patterns"
+  },
+  "author": "Lynx Authors",
+  "type": "module",
+  "files": [
+    "dist/",
+    "src/",
+    "lynx.config.ts",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev",
+    "preview": "rspeedy preview"
+  },
+  "dependencies": {
+    "@lynx-js/react": "catalog:"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
+    "@lynx-js/react-rsbuild-plugin": "catalog:",
+    "@lynx-js/rspeedy": "catalog:",
+    "@lynx-js/types": "catalog:",
+    "@rsbuild/plugin-type-check": "1.5.0",
+    "@types/react": "^18.3.28",
+    "typescript": "~5.9.3"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/examples/creator-card-patterns/src/App.css
+++ b/examples/creator-card-patterns/src/App.css
@@ -1,0 +1,311 @@
+page {
+  width: 100%;
+  height: 100%;
+  background-color: #f5f6fa;
+}
+
+.PageScroll {
+  width: 100%;
+  height: 100%;
+}
+
+.App {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px;
+  padding-bottom: 36px;
+}
+
+.Hero {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 22px;
+  border-radius: 24px;
+  background: linear-gradient(135deg, #20263a 0%, #495673 100%);
+}
+
+.Eyebrow {
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.Title {
+  color: #ffffff;
+  font-size: 28px;
+  font-weight: 800;
+  line-height: 34px;
+}
+
+.Description {
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.Section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.SectionTitle {
+  color: #1f2433;
+  font-size: 19px;
+  font-weight: 760;
+}
+
+.SectionSubtitle {
+  color: #5d6577;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.CardHeaderRow {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.ToggleText,
+.ResetText,
+.LinkButton {
+  color: #2864d7;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.Panel,
+.StatusPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border-radius: 18px;
+  background-color: #ffffff;
+}
+
+.AdaptiveHeadline {
+  color: #111827;
+  font-weight: 800;
+}
+
+.SmallNote {
+  color: #6b7280;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.MediaCard {
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+  padding: 8px;
+  border: 1px solid #e7eaf0;
+  border-radius: 18px;
+  background-color: #ffffff;
+}
+
+.MediaCardSelected {
+  border-color: #4f7cff;
+  background-color: #f4f7ff;
+}
+
+.MediaCoverSlot {
+  display: flex;
+}
+
+.Cover {
+  position: relative;
+  overflow: hidden;
+  border-radius: 14px;
+  background-color: #d9dee8;
+}
+
+.CoverImage,
+.AvatarImage,
+.InfoImage {
+  width: 100%;
+  height: 100%;
+}
+
+.CoverGradient {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 44px;
+  background: linear-gradient(
+    180deg,
+    rgba(16, 24, 40, 0) 0%,
+    rgba(16, 24, 40, 0.58) 100%
+  );
+}
+
+.PhotoBadge {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  width: 22px;
+  height: 22px;
+  border-radius: 11px;
+  background-color: rgba(17, 24, 39, 0.72);
+  color: #ffffff;
+  font-size: 13px;
+  line-height: 22px;
+  text-align: center;
+}
+
+.MediaBody {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 110px;
+}
+
+.MediaTitle {
+  color: #111827;
+  font-size: 16px;
+  font-weight: 750;
+  line-height: 20px;
+}
+
+.MediaSubtitle,
+.MediaTime,
+.AuthorName,
+.InfoDescription,
+.StatusText {
+  color: #667085;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.MediaSubtitle {
+  margin-top: 4px;
+}
+
+.MediaTime {
+  margin-bottom: 6px;
+}
+
+.AuthorRow {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+}
+
+.Avatar {
+  width: 18px;
+  height: 18px;
+  overflow: hidden;
+  border-radius: 9px;
+  background-color: #e5e7eb;
+}
+
+.InfoCard {
+  padding: 12px;
+  margin-top: 8px;
+  border-radius: 16px;
+  background-color: #ffffff;
+  border: 1px solid #e7eaf0;
+}
+
+.InfoMainRow {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.InfoIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 17px;
+  background-color: #eef4ff;
+}
+
+.InfoIconText {
+  color: #2f65d7;
+  font-size: 17px;
+  font-weight: 800;
+  text-align: center;
+}
+
+.InfoImage {
+  width: 52px;
+  height: 52px;
+  border-radius: 12px;
+  background-color: #edf0f5;
+}
+
+.InfoBody {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.InfoTitle {
+  color: #172033;
+  font-size: 15px;
+  font-weight: 760;
+  line-height: 20px;
+}
+
+.StrongButton {
+  align-self: flex-start;
+  margin-top: 4px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background-color: #111827;
+}
+
+.StrongButtonText {
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.CloseButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 13px;
+  background-color: #f2f4f7;
+}
+
+.CloseButtonText {
+  color: #667085;
+  font-size: 20px;
+  line-height: 22px;
+  text-align: center;
+}
+
+.EmptyState {
+  padding: 16px;
+  margin-top: 8px;
+  border: 1px dashed #cbd5e1;
+  border-radius: 16px;
+}
+
+.EmptyStateText {
+  color: #667085;
+  font-size: 14px;
+  text-align: center;
+}
+
+.StatusLabel {
+  color: #344054;
+  font-size: 13px;
+  font-weight: 800;
+}

--- a/examples/creator-card-patterns/src/App.tsx
+++ b/examples/creator-card-patterns/src/App.tsx
@@ -1,0 +1,85 @@
+import { useState } from "@lynx-js/react";
+
+import { AdaptiveText } from "./components/AdaptiveText.jsx";
+import { InfoCards } from "./components/InfoCards.jsx";
+import { MediaCard } from "./components/MediaCard.jsx";
+import { infoCards, longHeadline, mediaCards } from "./mockData.jsx";
+
+import "./App.css";
+
+export function App() {
+  const [selectedCardId, setSelectedCardId] = useState(mediaCards[0].id);
+  const [statusMessage, setStatusMessage] = useState("Tap a card, author, action, or close button.");
+  const [showLongText, setShowLongText] = useState(true);
+
+  return (
+    <page>
+      <scroll-view scroll-orientation="vertical" className="PageScroll">
+        <view className="App">
+          <view className="Hero">
+            <text className="Eyebrow">UI migration sample</text>
+            <text className="Title">Creator card patterns</text>
+            <text className="Description">
+              Three behavior-complete slices are wired with deterministic mock data and local callbacks.
+            </text>
+          </view>
+
+          <view className="Section">
+            <view className="CardHeaderRow">
+              <text className="SectionTitle">Adaptive text</text>
+              <text className="ToggleText" catchtap={() => setShowLongText(!showLongText)}>
+                Toggle copy
+              </text>
+            </view>
+            <view className="Panel">
+              <AdaptiveText
+                className="AdaptiveHeadline"
+                text-maxline="2"
+                maxFontSize={22}
+                minFontSize={14}
+                autoSizeStep={2}
+                lineHeightMultiplier={1.18}
+              >
+                {showLongText ? longHeadline : "Short titles keep their maximum size."}
+              </AdaptiveText>
+              <text className="SmallNote">
+                The text stays hidden while layout feedback steps the font down, then fades in when it fits.
+              </text>
+            </view>
+          </view>
+
+          <view className="Section">
+            <text className="SectionTitle">Media cards</text>
+            <view className="Panel">
+              {mediaCards.map((card) => (
+                <MediaCard
+                  key={card.id}
+                  {...card}
+                  selected={card.id === selectedCardId}
+                  onSelect={(id) => {
+                    setSelectedCardId(id);
+                    setStatusMessage(`Selected media card ${id}.`);
+                  }}
+                  onAuthorSelect={(id) => setStatusMessage(`Selected author area for ${id}.`)}
+                />
+              ))}
+            </view>
+          </view>
+
+          <view className="Section">
+            <InfoCards
+              cards={infoCards}
+              onShow={(key) => setStatusMessage(`Information card ${key} became visible.`)}
+              onAction={(key) => setStatusMessage(`Triggered action from ${key}.`)}
+            />
+          </view>
+
+          <view className="StatusPanel">
+            <text className="StatusLabel">Last event</text>
+            <text className="StatusText">{statusMessage}</text>
+          </view>
+        </view>
+      </scroll-view>
+    </page>
+  );
+}

--- a/examples/creator-card-patterns/src/components/AdaptiveText.tsx
+++ b/examples/creator-card-patterns/src/components/AdaptiveText.tsx
@@ -1,0 +1,59 @@
+import { useState } from "@lynx-js/react";
+
+type LineInfo = {
+  start: number;
+  end: number;
+  ellipsisCount: number;
+};
+
+type AdaptiveTextProps = {
+  children: React.ReactNode;
+  className?: string;
+  "text-maxline": string;
+  maxFontSize: number;
+  minFontSize?: number;
+  autoSizeStep?: number;
+  lineHeightMultiplier?: number;
+};
+
+export function AdaptiveText({
+  autoSizeStep = 1,
+  minFontSize = 0,
+  maxFontSize,
+  lineHeightMultiplier,
+  className,
+  children,
+  "text-maxline": textMaxLine,
+}: AdaptiveTextProps) {
+  const [fontSize, setFontSize] = useState(maxFontSize);
+  const [opacity, setOpacity] = useState(0);
+
+  const onLayout = (event: { detail: { lineCount: number; lines: LineInfo[] } }) => {
+    const { lineCount, lines } = event.detail;
+    const lastLine = lines[lineCount - 1];
+    const hasEllipsis = Boolean(lastLine?.ellipsisCount);
+
+    if (hasEllipsis && fontSize > minFontSize) {
+      setFontSize(Math.max(minFontSize, fontSize - autoSizeStep));
+      return;
+    }
+
+    setOpacity(1);
+  };
+
+  return (
+    <text
+      className={className}
+      text-maxline={textMaxLine}
+      bindlayout={onLayout}
+      style={{
+        textOverflow: "ellipsis",
+        fontSize: `${fontSize}px`,
+        ...(lineHeightMultiplier ? { lineHeight: `${fontSize * lineHeightMultiplier}px` } : {}),
+        opacity,
+      }}
+    >
+      {children}
+    </text>
+  );
+}

--- a/examples/creator-card-patterns/src/components/InfoCards.tsx
+++ b/examples/creator-card-patterns/src/components/InfoCards.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from "@lynx-js/react";
+
+export type InfoCardItem = {
+  key: string;
+  type: "basic" | "action" | "image";
+  title: string;
+  description: string;
+  icon?: string;
+  imageUrl?: string;
+  buttonText?: string;
+  isStrongAction?: boolean;
+  isDismissible?: boolean;
+};
+
+type InfoCardsProps = {
+  cards: InfoCardItem[];
+  onAction?: (key: string) => void;
+  onShow?: (key: string) => void;
+};
+
+function LeadingVisual({ card }: { card: InfoCardItem }) {
+  if (card.type === "image" && card.imageUrl) {
+    return <image className="InfoImage" src={card.imageUrl} mode="aspectFill" />;
+  }
+
+  return (
+    <view className="InfoIcon">
+      <text className="InfoIconText">{card.icon ?? "i"}</text>
+    </view>
+  );
+}
+
+function ActionButton({ card, onAction }: { card: InfoCardItem; onAction?: (key: string) => void }) {
+  if (!card.buttonText) {
+    return null;
+  }
+
+  if (card.isStrongAction) {
+    return (
+      <view className="StrongButton" catchtap={() => onAction?.(card.key)}>
+        <text className="StrongButtonText">{card.buttonText}</text>
+      </view>
+    );
+  }
+
+  return (
+    <text className="LinkButton" catchtap={() => onAction?.(card.key)}>
+      {card.buttonText}
+    </text>
+  );
+}
+
+function InfoCard({ card, onClose, onAction, onShow }: {
+  card: InfoCardItem;
+  onClose: (key: string) => void;
+  onAction?: (key: string) => void;
+  onShow?: (key: string) => void;
+}) {
+  const [descriptionMaxLine, setDescriptionMaxLine] = useState("2");
+
+  useEffect(() => {
+    onShow?.(card.key);
+  }, [card.key, onShow]);
+
+  const onTitleLayout = (event: { detail: { lineCount: number } }) => {
+    setDescriptionMaxLine(event.detail.lineCount >= 2 ? "1" : "2");
+  };
+
+  const handleCardTap = () => {
+    if (!card.isStrongAction) {
+      onAction?.(card.key);
+    }
+  };
+
+  return (
+    <view className="InfoCard" bindtap={handleCardTap}>
+      <view className="InfoMainRow">
+        <LeadingVisual card={card} />
+        <view className="InfoBody">
+          <text
+            className="InfoTitle"
+            bindlayout={onTitleLayout}
+            text-maxline="2"
+            style={{ textOverflow: "ellipsis" }}
+          >
+            {card.title}
+          </text>
+          <text className="InfoDescription" text-maxline={descriptionMaxLine} style={{ textOverflow: "ellipsis" }}>
+            {card.description}
+          </text>
+          <ActionButton card={card} onAction={onAction} />
+        </view>
+        {card.isDismissible !== false && (
+          <view className="CloseButton" catchtap={() => onClose(card.key)}>
+            <text className="CloseButtonText">×</text>
+          </view>
+        )}
+      </view>
+    </view>
+  );
+}
+
+export function InfoCards({ cards, onAction, onShow }: InfoCardsProps) {
+  const [visibleCards, setVisibleCards] = useState(cards);
+
+  const closeCard = (key: string) => {
+    setVisibleCards((current) => current.filter((card) => card.key !== key));
+  };
+
+  const resetCards = () => {
+    setVisibleCards(cards);
+  };
+
+  return (
+    <view>
+      <view className="CardHeaderRow">
+        <text className="SectionSubtitle">Dismissible list with variants</text>
+        <text className="ResetText" catchtap={resetCards}>Reset</text>
+      </view>
+      {visibleCards.map((card) => (
+        <InfoCard key={card.key} card={card} onClose={closeCard} onAction={onAction} onShow={onShow} />
+      ))}
+      {visibleCards.length === 0 && (
+        <view className="EmptyState">
+          <text className="EmptyStateText">All cards dismissed. Tap Reset to restore them.</text>
+        </view>
+      )}
+    </view>
+  );
+}

--- a/examples/creator-card-patterns/src/components/MediaCard.tsx
+++ b/examples/creator-card-patterns/src/components/MediaCard.tsx
@@ -1,0 +1,71 @@
+export type MediaCardItem = {
+  id: string;
+  title: string;
+  subtitle: string;
+  cover: {
+    width: string;
+    height: string;
+    imageUrl: string;
+  };
+  timeInfo?: string;
+  author?: {
+    avatar: string;
+    name: string;
+  };
+  isPhotoMode?: boolean;
+};
+
+type MediaCardProps = MediaCardItem & {
+  selected?: boolean;
+  onSelect?: (id: string) => void;
+  onAuthorSelect?: (id: string) => void;
+};
+
+function Avatar({ avatar, name }: { avatar: string; name: string }) {
+  return (
+    <view className="Avatar">
+      <image className="AvatarImage" src={avatar} mode="aspectFill" />
+    </view>
+  );
+}
+
+function MediaCover({ item }: { item: MediaCardItem }) {
+  return (
+    <view className="Cover" style={{ width: item.cover.width, height: item.cover.height }}>
+      <image className="CoverImage" src={item.cover.imageUrl} mode="aspectFill" />
+      <view className="CoverGradient" />
+      {item.isPhotoMode && <text className="PhotoBadge">▧</text>}
+    </view>
+  );
+}
+
+export function MediaCard({ selected, onSelect, onAuthorSelect, ...item }: MediaCardProps) {
+  return (
+    <view className={selected ? "MediaCard MediaCardSelected" : "MediaCard"} bindtap={() => onSelect?.(item.id)}>
+      <view className="MediaCoverSlot">
+        <MediaCover item={item} />
+      </view>
+      <view className="MediaBody">
+        <view>
+          <text className="MediaTitle" text-maxline="2" style={{ textOverflow: "ellipsis" }}>
+            {item.title}
+          </text>
+          <text className="MediaSubtitle" text-maxline="2" style={{ textOverflow: "ellipsis" }}>
+            {item.subtitle}
+          </text>
+        </view>
+        <view>
+          {item.timeInfo && <text className="MediaTime">{item.timeInfo}</text>}
+          {item.author && (
+            <view className="AuthorRow" catchtap={() => onAuthorSelect?.(item.id)}>
+              <Avatar avatar={item.author.avatar} name={item.author.name} />
+              <text className="AuthorName" text-maxline="1" style={{ textOverflow: "ellipsis" }}>
+                {item.author.name}
+              </text>
+            </view>
+          )}
+        </view>
+      </view>
+    </view>
+  );
+}

--- a/examples/creator-card-patterns/src/index.tsx
+++ b/examples/creator-card-patterns/src/index.tsx
@@ -1,0 +1,9 @@
+import { root } from "@lynx-js/react";
+
+import { App } from "./App.jsx";
+
+root.render(<App />);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/creator-card-patterns/src/mockData.tsx
+++ b/examples/creator-card-patterns/src/mockData.tsx
@@ -1,0 +1,65 @@
+import type { InfoCardItem } from "./components/InfoCards.jsx";
+import type { MediaCardItem } from "./components/MediaCard.jsx";
+
+export const longHeadline =
+  "Plan a compact dashboard card that keeps the most useful insight visible even when the title becomes unusually long.";
+
+export const mediaCards: MediaCardItem[] = [
+  {
+    id: "clip-01",
+    title: "Weekend sketchbook: mural details and tiny process notes",
+    subtitle: "23.5k views in the last 7 days",
+    cover: {
+      width: "82px",
+      height: "110px",
+      imageUrl: "https://images.unsplash.com/photo-1495567720989-cebdbdd97913?w=240&h=320&fit=crop",
+    },
+    timeInfo: "1 hour ago",
+    author: {
+      avatar: "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=80&h=80&fit=crop",
+      name: "Studio Notes",
+    },
+    isPhotoMode: true,
+  },
+  {
+    id: "clip-02",
+    title: "Metro note",
+    subtitle: "A shorter card keeps the bottom metadata aligned.",
+    cover: {
+      width: "82px",
+      height: "110px",
+      imageUrl: "https://images.unsplash.com/photo-1519501025264-65ba15a82390?w=240&h=320&fit=crop",
+    },
+    timeInfo: "Posted on Sep 3",
+  },
+];
+
+export const infoCards: InfoCardItem[] = [
+  {
+    key: "basic",
+    type: "basic",
+    title: "Your weekly summary is ready",
+    description: "A lightweight card can be dismissed without affecting the rest of the list.",
+    icon: "✓",
+    isDismissible: true,
+  },
+  {
+    key: "action",
+    type: "action",
+    title: "Try a new posting schedule",
+    description: "Action cards keep their tap target available even when the title occupies two lines.",
+    icon: "↗",
+    buttonText: "Apply",
+    isStrongAction: true,
+    isDismissible: true,
+  },
+  {
+    key: "image",
+    type: "image",
+    title: "Cover refresh recommendation",
+    description: "Image cards reserve leading media space and preserve the same close behavior.",
+    imageUrl: "https://images.unsplash.com/photo-1518005020951-eccb494ad742?w=160&h=160&fit=crop",
+    buttonText: "Preview",
+    isDismissible: false,
+  },
+];

--- a/examples/creator-card-patterns/src/rspeedy-env.d.ts
+++ b/examples/creator-card-patterns/src/rspeedy-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@lynx-js/rspeedy/client" />

--- a/examples/creator-card-patterns/tsconfig.json
+++ b/examples/creator-card-patterns/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "@lynx-js/react",
+
+    "module": "node16",
+    "moduleResolution": "node16",
+
+    "strict": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+  },
+  "exclude": ["dist/"],
+}

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "sort-package-json": "^4.0.0",
     "turbo": "^2.8.13"
   },
-  "packageManager": "pnpm@11.13.0",
+  "packageManager": "pnpm@11.14.0",
   "engines": {
     "node": ">=22",
-    "pnpm": "11.13.0"
+    "pnpm": "11.14.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,19 +86,19 @@ importers:
     devDependencies:
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.6.0(@lynx-js/rspeedy@0.16.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.101.3(postcss@8.5.19)))
+        version: 0.6.0(@lynx-js/rspeedy@0.16.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.101.3))
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
         version: 0.18.0(@lynx-js/react@0.123.0(@lynx-js/types@4.0.0)(@types/react@18.3.28))(tslib@2.8.1)
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.16.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.101.3(postcss@8.5.19))
+        version: 0.16.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.101.3)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 4.0.0
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.4(core-js@3.47.0))
+        version: 2.0.1(@rsbuild/core@2.1.6(core-js@3.47.0))
       '@types/react':
         specifier: ^18.3.28
         version: 18.3.28
@@ -367,6 +367,34 @@ importers:
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 4.0.0
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+
+  examples/creator-card-patterns:
+    dependencies:
+      '@lynx-js/react':
+        specifier: 'catalog:'
+        version: 0.123.0(@lynx-js/types@4.0.0)(@types/react@18.3.28)
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.6.0(@lynx-js/rspeedy@0.16.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.101.3(postcss@8.5.19)))
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.18.0(@lynx-js/react@0.123.0(@lynx-js/types@4.0.0)(@types/react@18.3.28))(tslib@2.8.1)
+      '@lynx-js/rspeedy':
+        specifier: 'catalog:'
+        version: 0.16.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.101.3(postcss@8.5.19))
+      '@lynx-js/types':
+        specifier: 'catalog:'
+        version: 4.0.0
+      '@rsbuild/plugin-type-check':
+        specifier: 1.5.0
+        version: 1.5.0(@rsbuild/core@2.1.4(core-js@3.47.0))(@rspack/core@2.1.4(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@5.9.3)
       '@types/react':
         specifier: ^18.3.28
         version: 18.3.28
@@ -10928,16 +10956,6 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.1.4(core-js@3.47.0))':
-    dependencies:
-      deepmerge: 4.3.1
-      loader-utils: 2.0.4
-      postcss: 8.5.19
-      reduce-configs: 2.0.1
-      sass-embedded: 1.100.0
-    optionalDependencies:
-      '@rsbuild/core': 2.1.4(core-js@3.47.0)
-
   '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.1.6(core-js@3.47.0))':
     dependencies:
       deepmerge: 4.3.1
@@ -10959,6 +10977,19 @@ snapshots:
       - '@rspack/core'
       - supports-color
       - webpack
+
+  '@rsbuild/plugin-type-check@1.5.0(@rsbuild/core@2.1.4(core-js@3.47.0))(@rspack/core@2.1.4(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@5.9.3)':
+    dependencies:
+      deepmerge: 4.3.1
+      json5: 2.2.3
+      reduce-configs: 1.1.2
+      ts-checker-rspack-plugin: 1.5.2(@rspack/core@2.1.4(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@5.9.3)
+    optionalDependencies:
+      '@rsbuild/core': 2.1.4(core-js@3.47.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - tslib
+      - typescript
 
   '@rsbuild/plugin-type-check@1.5.0(@rsbuild/core@2.1.6(core-js@3.47.0))(@rspack/core@2.1.4(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:


### PR DESCRIPTION
## Summary

- Add `examples/creator-card-patterns/` with three migrated UI slices: adaptive text, media cards, and dismissible information cards.
- Preserve the original component behavior while replacing business boundaries with deterministic mock data and public Lynx elements.
- Bump pinned pnpm from `11.13.0` to `11.14.0` because `11.13.0` is rejected by Corepack as a broken release in this environment.

## Validation

- `pnpm --filter @lynx-example/creator-card-patterns run build`: pass
- `pnpm dprint check`: pass
- `pnpm meta-updater --test`: pass
- Sensitive keyword scan for `byted|tiktok|douyin|aweme|anniex`: pass
- Private dependency scan for internal package/domain markers: pass

## Risk

- No screenshots attached; validation was limited to build and static gates in this run.
- Business navigation, analytics, private design tokens, and live data are intentionally replaced with local callbacks and stable mocks.
