### PR TITLE
Add sticky position web example

### DIFF
--- a/.changeset/bright-sticky-position.md
+++ b/.changeset/bright-sticky-position.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/css-api": patch
+---
+
+Add a `position: sticky` case to the `position` API example and build a Web bundle for that entry.

--- a/api/css/lynx.web.config.mjs
+++ b/api/css/lynx.web.config.mjs
@@ -1,0 +1,19 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import config from "./lynx.config.mjs";
+
+config.source.entry = {
+  position: "./src/position/App.tsx",
+};
+
+config.environments = {
+  web: {},
+};
+
+config.output ??= {};
+config.output.cleanDistPath = false;
+config.output.filename = "[name].[platform].bundle";
+
+export default config;

--- a/api/css/package.json
+++ b/api/css/package.json
@@ -14,6 +14,7 @@
     "dist/",
     "src/",
     "resource/",
+    "lynx.web.config.mjs",
     "lynx.config.mjs"
   ],
   "scripts": {

--- a/api/css/scripts/build.mjs
+++ b/api/css/scripts/build.mjs
@@ -7,8 +7,8 @@ import { spawnSync } from "node:child_process";
 const command = process.platform === "win32" ? "rspeedy.cmd" : "rspeedy";
 const chunks = Number(process.env.CSS_API_BUILD_CHUNKS ?? 8);
 
-function runBuild(env = {}) {
-  const result = spawnSync(command, ["build"], {
+function runBuild(args = ["build"], env = {}) {
+  const result = spawnSync(command, args, {
     env: {
       ...process.env,
       ...env,
@@ -23,13 +23,16 @@ function runBuild(env = {}) {
 
 if (process.env.CI !== "1") {
   runBuild();
+  runBuild(["build", "--config", "lynx.web.config.mjs"]);
   process.exit(0);
 }
 
 for (let index = 0; index < chunks; index++) {
   console.log(`Building CSS API entries chunk ${index + 1}/${chunks}`);
-  runBuild({
+  runBuild(["build"], {
     CSS_API_BUILD_CHUNK_INDEX: String(index),
     CSS_API_BUILD_CHUNKS: String(chunks),
   });
 }
+
+runBuild(["build", "--config", "lynx.web.config.mjs"]);

--- a/api/css/src/position/App.tsx
+++ b/api/css/src/position/App.tsx
@@ -130,10 +130,42 @@ const Position = () => {
       height: "50px",
       backgroundColor: "blue",
     },
+    leadIn: {
+      height: "72px",
+      justifyContent: "center" as const,
+      alignItems: "center" as const,
+      backgroundColor: "#f4f4f5",
+    },
+    stickyHeader: {
+      position: "sticky" as const,
+      top: "0px",
+      zIndex: 1,
+      width: "750rpx",
+      height: "44px",
+      justifyContent: "center" as const,
+      alignItems: "center" as const,
+      backgroundColor: "#111827",
+    },
+    stickyText: {
+      color: "#ffffff",
+      fontSize: "14px",
+    },
+    tail: {
+      height: "260px",
+      justifyContent: "center" as const,
+      alignItems: "center" as const,
+      backgroundColor: "#f4f4f5",
+    },
   };
 
   return (
     <scroll-view className="root" scroll-orientation="vertical">
+      <view style={boxStyles.leadIn}>
+        <text>Scroll to see position: sticky</text>
+      </view>
+      <view style={boxStyles.stickyHeader}>
+        <text style={boxStyles.stickyText}>position: sticky; top: 0</text>
+      </view>
       <view className="fixed_area">
         <view className="container">
           <view style={boxStyles.fixed1}></view>
@@ -153,6 +185,9 @@ const Position = () => {
           <view style={boxStyles.absolute10}></view>
           <view style={boxStyles.fixed6}></view>
         </view>
+      </view>
+      <view style={boxStyles.tail}>
+        <text>The sticky bar stays at the top while scrolling.</text>
       </view>
     </scroll-view>
   );


### PR DESCRIPTION
## Summary
- add a position: sticky case to the css-api position example
- add a web-only config for the position entry so css-api publishes position.web.bundle
- include a patch changeset for @lynx-example/css-api

## Validation
- pnpm --filter @lynx-example/css-api run build
- pnpm meta-updater --test
- pnpm changeset status --verbose --since origin/main