### PR TITLE
feat(examples): add migrated UI pattern examples

### DIFF
--- a/.changeset/neat-controls-adapt.md
+++ b/.changeset/neat-controls-adapt.md
@@ -1,0 +1,7 @@
+---
+"@lynx-example/adaptive-text": minor
+"@lynx-example/segmented-control": minor
+"@lynx-example/tag-choice": minor
+---
+
+Add three public UI examples for layout-driven text sizing, controlled segmented selection, and multi-select tag choices.

--- a/examples/adaptive-text/CHANGELOG.md
+++ b/examples/adaptive-text/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @lynx-example/adaptive-text
+
+## 0.1.0
+
+### Minor Changes
+
+- Add a layout-driven adaptive text example.

--- a/examples/adaptive-text/README.md
+++ b/examples/adaptive-text/README.md
@@ -1,0 +1,20 @@
+# Adaptive Text
+
+This example shrinks text in fixed steps until layout feedback reports that the final line no longer contains an ellipsis.
+
+## Behavior
+
+- Text starts at the configured maximum font size and remains hidden while measuring.
+- Each overflowing layout pass decreases the size by the configured step.
+- The component stops at the minimum size or when the text fits, then becomes visible.
+- Line height follows the configured multiplier.
+- Reset remounts the component at its maximum size.
+
+## Commands
+
+```bash
+pnpm --filter @lynx-example/adaptive-text dev
+pnpm --filter @lynx-example/adaptive-text build
+```
+
+This example intentionally excludes remote fonts and host-specific text services.

--- a/examples/adaptive-text/lynx.config.ts
+++ b/examples/adaptive-text/lynx.config.ts
@@ -1,0 +1,17 @@
+import { pluginQRCode } from "@lynx-js/qrcode-rsbuild-plugin";
+import { pluginReactLynx } from "@lynx-js/react-rsbuild-plugin";
+import { defineConfig } from "@lynx-js/rspeedy";
+
+export default defineConfig({
+  plugins: [
+    pluginQRCode(),
+    pluginReactLynx(),
+  ],
+  output: {
+    filename: "[name].[platform].bundle",
+  },
+  environments: {
+    web: {},
+    lynx: {},
+  },
+});

--- a/examples/adaptive-text/package.json
+++ b/examples/adaptive-text/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@lynx-example/adaptive-text",
+  "version": "0.1.0",
+  "description": "An example shows how to shrink overflowing text from layout feedback in Lynx",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lynx-family/lynx-examples.git",
+    "directory": "examples/adaptive-text"
+  },
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
+  "type": "module",
+  "files": [
+    "dist/",
+    "src/",
+    "lynx.config.ts",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev",
+    "preview": "rspeedy preview"
+  },
+  "dependencies": {
+    "@lynx-js/react": "catalog:"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
+    "@lynx-js/react-rsbuild-plugin": "catalog:",
+    "@lynx-js/rspeedy": "catalog:",
+    "@lynx-js/types": "catalog:",
+    "@types/react": "^18.3.28",
+    "typescript": "~5.9.3"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/examples/adaptive-text/src/App.css
+++ b/examples/adaptive-text/src/App.css
@@ -1,0 +1,115 @@
+:root {
+  background-color: #ecfdf5;
+}
+
+.Page {
+  min-height: 100vh;
+  padding: 48rpx 28rpx;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.Card {
+  width: 100%;
+  padding: 34rpx;
+  border-radius: 30rpx;
+  background-color: #ffffff;
+  box-shadow: 0 18rpx 50rpx rgba(16, 86, 65, 0.14);
+}
+
+.Eyebrow {
+  color: #059669;
+  font-size: 20rpx;
+  font-weight: 700;
+  letter-spacing: 2rpx;
+}
+
+.Title {
+  margin-top: 12rpx;
+  color: #13352b;
+  font-size: 42rpx;
+  font-weight: 700;
+}
+
+.SampleTabs {
+  margin-top: 26rpx;
+  display: flex;
+  flex-direction: row;
+  gap: 12rpx;
+}
+
+.SampleTab {
+  height: 58rpx;
+  padding: 0 22rpx;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 18rpx;
+  background-color: #e8f5ef;
+}
+
+.SampleTab--active {
+  background-color: #059669;
+}
+
+.SampleTab__text {
+  color: #397264;
+  font-size: 23rpx;
+  font-weight: 600;
+}
+
+.SampleTab__text--active {
+  color: #ffffff;
+}
+
+.HeadlineFrame {
+  height: 154rpx;
+  margin-top: 24rpx;
+  padding: 22rpx;
+  display: flex;
+  align-items: center;
+  border-radius: 22rpx;
+  background: linear-gradient(135deg, #d1fae5, #f0fdf4);
+}
+
+.Headline {
+  width: 100%;
+  color: #13352b;
+  font-weight: 700;
+}
+
+.Status {
+  margin-top: 22rpx;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.Status__label {
+  color: #658078;
+  font-size: 24rpx;
+}
+
+.Status__value {
+  color: #059669;
+  font-size: 24rpx;
+  font-weight: 700;
+}
+
+.Reset {
+  height: 72rpx;
+  margin-top: 24rpx;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 20rpx;
+  background-color: #13352b;
+}
+
+.Reset__text {
+  color: #ffffff;
+  font-size: 24rpx;
+  font-weight: 600;
+}

--- a/examples/adaptive-text/src/App.tsx
+++ b/examples/adaptive-text/src/App.tsx
@@ -1,0 +1,71 @@
+import { useState } from "@lynx-js/react";
+
+import "./App.css";
+import { AdaptiveText } from "./components/AdaptiveText.jsx";
+import { textSamples } from "./mockData.js";
+
+export function App() {
+  const [sampleIndex, setSampleIndex] = useState(2);
+  const [renderKey, setRenderKey] = useState(0);
+  const [resolvedSize, setResolvedSize] = useState(0);
+  const sample = textSamples[sampleIndex];
+
+  const selectSample = (index: number) => {
+    setSampleIndex(index);
+    setResolvedSize(0);
+    setRenderKey(renderKey + 1);
+  };
+
+  return (
+    <page className="Page">
+      <view className="Card">
+        <text className="Eyebrow">LAYOUT FEEDBACK</text>
+        <text className="Title">Adaptive headline</text>
+        <view className="SampleTabs">
+          {textSamples.map((item, index) => (
+            <view
+              key={item.id}
+              className={`SampleTab${sampleIndex === index ? " SampleTab--active" : ""}`}
+              bindtap={() => selectSample(index)}
+            >
+              <text
+                className={`SampleTab__text${sampleIndex === index ? " SampleTab__text--active" : ""}`}
+              >
+                {item.label}
+              </text>
+            </view>
+          ))}
+        </view>
+        <view className="HeadlineFrame">
+          <AdaptiveText
+            key={renderKey}
+            className="Headline"
+            text-maxline="2"
+            maxFontSize={52}
+            minFontSize={28}
+            autoSizeStep={4}
+            lineHeightMultiplier={1.12}
+            onSizeResolved={setResolvedSize}
+          >
+            {sample.text}
+          </AdaptiveText>
+        </view>
+        <view className="Status">
+          <text className="Status__label">Resolved size</text>
+          <text className="Status__value">
+            {resolvedSize ? `${resolvedSize}rpx` : "Measuring"}
+          </text>
+        </view>
+        <view
+          className="Reset"
+          bindtap={() => {
+            setResolvedSize(0);
+            setRenderKey(renderKey + 1);
+          }}
+        >
+          <text className="Reset__text">Measure again</text>
+        </view>
+      </view>
+    </page>
+  );
+}

--- a/examples/adaptive-text/src/components/AdaptiveText.tsx
+++ b/examples/adaptive-text/src/components/AdaptiveText.tsx
@@ -1,0 +1,58 @@
+import { useState } from "@lynx-js/react";
+
+interface LineInfo {
+  start: number;
+  end: number;
+  ellipsisCount: number;
+}
+
+type AdaptiveTextProps = JSX.IntrinsicElements["text"] & {
+  style?: ReactLynx.CSSProperties;
+  "text-maxline": number | string;
+  maxFontSize: number;
+  minFontSize?: number;
+  autoSizeStep?: number;
+  lineHeightMultiplier?: number;
+  onSizeResolved?: (fontSize: number) => void;
+};
+
+export function AdaptiveText(props: AdaptiveTextProps) {
+  const {
+    autoSizeStep = 1,
+    minFontSize = 0,
+    onSizeResolved,
+  } = props;
+  const [fontSize, setFontSize] = useState(props.maxFontSize);
+  const [opacity, setOpacity] = useState(0);
+
+  const onLayout = (event: {
+    detail: { lineCount: number; lines: LineInfo[] };
+  }) => {
+    const { lineCount, lines } = event.detail;
+    const lastLine = lines[lineCount - 1];
+    const hasEllipsis = lastLine.ellipsisCount > 0;
+
+    if (hasEllipsis && fontSize > minFontSize) {
+      setFontSize(fontSize - autoSizeStep);
+    } else {
+      setOpacity(1);
+      onSizeResolved?.(fontSize);
+    }
+  };
+
+  const styles = {
+    ...(props.style ? props.style : {}),
+    textOverflow: "ellipsis",
+    fontSize: `${fontSize}rpx`,
+    opacity,
+    ...(props.lineHeightMultiplier
+      ? { lineHeight: `${fontSize * props.lineHeightMultiplier}rpx` }
+      : {}),
+  };
+
+  return (
+    <text {...props} style={styles} bindlayout={onLayout}>
+      {props.children}
+    </text>
+  );
+}

--- a/examples/adaptive-text/src/index.tsx
+++ b/examples/adaptive-text/src/index.tsx
@@ -1,0 +1,9 @@
+import { root } from "@lynx-js/react";
+
+import { App } from "./App.jsx";
+
+root.render(<App />);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/adaptive-text/src/mockData.ts
+++ b/examples/adaptive-text/src/mockData.ts
@@ -1,0 +1,17 @@
+export const textSamples = [
+  {
+    id: "short",
+    label: "Short",
+    text: "Layout-aware text",
+  },
+  {
+    id: "medium",
+    label: "Medium",
+    text: "A responsive heading that adapts to the space available",
+  },
+  {
+    id: "long",
+    label: "Long",
+    text: "A long headline keeps shrinking in predictable steps until it fits inside the fixed two-line card",
+  },
+];

--- a/examples/adaptive-text/src/rspeedy-env.d.ts
+++ b/examples/adaptive-text/src/rspeedy-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@lynx-js/rspeedy/client" />

--- a/examples/adaptive-text/tsconfig.json
+++ b/examples/adaptive-text/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "@lynx-js/react",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "strict": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+  },
+  "exclude": [
+    "dist/",
+  ],
+}

--- a/examples/segmented-control/CHANGELOG.md
+++ b/examples/segmented-control/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @lynx-example/segmented-control
+
+## 0.1.0
+
+### Minor Changes
+
+- Add a controlled segmented control example.

--- a/examples/segmented-control/README.md
+++ b/examples/segmented-control/README.md
@@ -1,0 +1,19 @@
+# Segmented Control
+
+This example implements a controlled segmented selector with an optional trailing indicator and disabled visual state.
+
+## Behavior
+
+- The parent owns the selected value.
+- Every item forwards its value when tapped.
+- The disabled state changes opacity while preserving the source interaction semantics.
+- Reset restores the initial selection.
+
+## Commands
+
+```bash
+pnpm --filter @lynx-example/segmented-control dev
+pnpm --filter @lynx-example/segmented-control build
+```
+
+This example intentionally excludes product navigation, analytics, theme services, and private icon packages.

--- a/examples/segmented-control/lynx.config.ts
+++ b/examples/segmented-control/lynx.config.ts
@@ -1,0 +1,17 @@
+import { pluginQRCode } from "@lynx-js/qrcode-rsbuild-plugin";
+import { pluginReactLynx } from "@lynx-js/react-rsbuild-plugin";
+import { defineConfig } from "@lynx-js/rspeedy";
+
+export default defineConfig({
+  plugins: [
+    pluginQRCode(),
+    pluginReactLynx(),
+  ],
+  output: {
+    filename: "[name].[platform].bundle",
+  },
+  environments: {
+    web: {},
+    lynx: {},
+  },
+});

--- a/examples/segmented-control/package.json
+++ b/examples/segmented-control/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@lynx-example/segmented-control",
+  "version": "0.1.0",
+  "description": "An example shows how to build a stateful segmented control in Lynx",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lynx-family/lynx-examples.git",
+    "directory": "examples/segmented-control"
+  },
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
+  "type": "module",
+  "files": [
+    "dist/",
+    "src/",
+    "lynx.config.ts",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev",
+    "preview": "rspeedy preview"
+  },
+  "dependencies": {
+    "@lynx-js/react": "catalog:"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
+    "@lynx-js/react-rsbuild-plugin": "catalog:",
+    "@lynx-js/rspeedy": "catalog:",
+    "@lynx-js/types": "catalog:",
+    "@types/react": "^18.3.28",
+    "typescript": "~5.9.3"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/examples/segmented-control/src/App.css
+++ b/examples/segmented-control/src/App.css
@@ -1,0 +1,144 @@
+:root {
+  background-color: #eef2ff;
+}
+
+.Page {
+  min-height: 100vh;
+  padding: 48rpx 28rpx;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.Card {
+  width: 100%;
+  padding: 32rpx;
+  border-radius: 28rpx;
+  background-color: #ffffff;
+  box-shadow: 0 18rpx 48rpx rgba(35, 47, 98, 0.14);
+}
+
+.Eyebrow {
+  color: #635bff;
+  font-size: 20rpx;
+  font-weight: 700;
+  letter-spacing: 2rpx;
+}
+
+.Title {
+  margin-top: 12rpx;
+  color: #171a2d;
+  font-size: 42rpx;
+  font-weight: 700;
+}
+
+.Description {
+  margin-top: 12rpx;
+  margin-bottom: 32rpx;
+  color: #646b85;
+  font-size: 26rpx;
+  line-height: 38rpx;
+}
+
+.SegmentedControl {
+  width: 100%;
+  height: 64rpx;
+  padding: 4rpx;
+  display: flex;
+  flex-direction: row;
+  border-radius: 32rpx;
+  background-color: #edf0f6;
+}
+
+.SegmentedControl__item {
+  min-width: 128rpx;
+  padding: 11rpx 20rpx;
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  border-radius: 28rpx;
+}
+
+.SegmentedControl__item--selected {
+  background-color: #ffffff;
+  box-shadow: 0 4rpx 14rpx rgba(34, 43, 78, 0.12);
+}
+
+.SegmentedControl__label {
+  color: #7a8198;
+  font-size: 22rpx;
+  font-weight: 600;
+  text-overflow: ellipsis;
+}
+
+.SegmentedControl__label--selected {
+  color: #1e2440;
+}
+
+.SegmentedControl__indicator {
+  margin-left: 4rpx;
+  color: #7a8198;
+  font-size: 20rpx;
+}
+
+.SegmentedControl__indicator--selected {
+  color: #1e2440;
+}
+
+.Status {
+  margin-top: 28rpx;
+  padding: 20rpx;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: 18rpx;
+  background-color: #f7f8fc;
+}
+
+.Status__label {
+  color: #777e95;
+  font-size: 24rpx;
+}
+
+.Status__value {
+  color: #635bff;
+  font-size: 24rpx;
+  font-weight: 700;
+}
+
+.Actions {
+  margin-top: 24rpx;
+  display: flex;
+  flex-direction: row;
+  gap: 16rpx;
+}
+
+.Button {
+  height: 76rpx;
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  border-radius: 20rpx;
+}
+
+.Button--secondary {
+  background-color: #edf0f6;
+}
+
+.Button--primary {
+  background-color: #635bff;
+}
+
+.Button__text {
+  color: #343a55;
+  font-size: 23rpx;
+  font-weight: 600;
+}
+
+.Button__text--primary {
+  color: #ffffff;
+}

--- a/examples/segmented-control/src/App.tsx
+++ b/examples/segmented-control/src/App.tsx
@@ -1,0 +1,51 @@
+import { useState } from "@lynx-js/react";
+
+import "./App.css";
+import { SegmentedControl } from "./components/SegmentedControl.jsx";
+import { initialSegment, segmentItems } from "./mockData.js";
+
+export function App() {
+  const [selectedValue, setSelectedValue] = useState(initialSegment);
+  const [isDisabled, setIsDisabled] = useState(false);
+
+  return (
+    <page className="Page">
+      <view className="Card">
+        <text className="Eyebrow">CONTROL PATTERN</text>
+        <text className="Title">Choose a reporting range</text>
+        <text className="Description">
+          The selected value is owned by the parent and updated by item taps.
+        </text>
+        <SegmentedControl
+          value={selectedValue}
+          onChange={setSelectedValue}
+          items={segmentItems}
+          isDisabled={isDisabled}
+        />
+        <view className="Status">
+          <text className="Status__label">Selected value</text>
+          <text className="Status__value">{selectedValue}</text>
+        </view>
+        <view className="Actions">
+          <view
+            className="Button Button--secondary"
+            bindtap={() => setIsDisabled(!isDisabled)}
+          >
+            <text className="Button__text">
+              {isDisabled ? "Restore opacity" : "Show disabled state"}
+            </text>
+          </view>
+          <view
+            className="Button Button--primary"
+            bindtap={() => {
+              setSelectedValue(initialSegment);
+              setIsDisabled(false);
+            }}
+          >
+            <text className="Button__text Button__text--primary">Reset</text>
+          </view>
+        </view>
+      </view>
+    </page>
+  );
+}

--- a/examples/segmented-control/src/components/SegmentedControl.tsx
+++ b/examples/segmented-control/src/components/SegmentedControl.tsx
@@ -1,0 +1,50 @@
+import type { SegmentItem } from "../mockData.js";
+
+interface SegmentedControlProps {
+  value: string;
+  onChange: (newValue: string) => void;
+  items: SegmentItem[];
+  isDisabled?: boolean;
+}
+
+export function SegmentedControl({
+  items,
+  value,
+  onChange,
+  isDisabled = false,
+}: SegmentedControlProps) {
+  return (
+    <view
+      className="SegmentedControl"
+      style={{ opacity: isDisabled ? 0.48 : 1 }}
+    >
+      {items.map((item) => {
+        const isSelected = value === item.value;
+
+        return (
+          <view
+            key={item.value}
+            className={`SegmentedControl__item${isSelected ? " SegmentedControl__item--selected" : ""}`}
+            bindtap={() => onChange(item.value)}
+          >
+            <text
+              text-maxline="1"
+              className={`SegmentedControl__label${isSelected ? " SegmentedControl__label--selected" : ""}`}
+            >
+              {item.title}
+            </text>
+            {item.trailingIcon
+              ? (
+                <text
+                  className={`SegmentedControl__indicator${isSelected ? " SegmentedControl__indicator--selected" : ""}`}
+                >
+                  ▾
+                </text>
+              )
+              : null}
+          </view>
+        );
+      })}
+    </view>
+  );
+}

--- a/examples/segmented-control/src/index.tsx
+++ b/examples/segmented-control/src/index.tsx
@@ -1,0 +1,9 @@
+import { root } from "@lynx-js/react";
+
+import { App } from "./App.jsx";
+
+root.render(<App />);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/segmented-control/src/mockData.ts
+++ b/examples/segmented-control/src/mockData.ts
@@ -1,0 +1,14 @@
+export interface SegmentItem {
+  value: string;
+  title: string;
+  trailingIcon?: boolean;
+}
+
+export const segmentItems: SegmentItem[] = [
+  { value: "week", title: "7 days" },
+  { value: "month", title: "28 days" },
+  { value: "quarter", title: "60 days" },
+  { value: "custom", title: "Custom", trailingIcon: true },
+];
+
+export const initialSegment = segmentItems[0].value;

--- a/examples/segmented-control/src/rspeedy-env.d.ts
+++ b/examples/segmented-control/src/rspeedy-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@lynx-js/rspeedy/client" />

--- a/examples/segmented-control/tsconfig.json
+++ b/examples/segmented-control/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "@lynx-js/react",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "strict": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+  },
+  "exclude": [
+    "dist/",
+  ],
+}

--- a/examples/tag-choice/CHANGELOG.md
+++ b/examples/tag-choice/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @lynx-example/tag-choice
+
+## 0.1.0
+
+### Minor Changes
+
+- Add a controlled multi-select tag choice example.

--- a/examples/tag-choice/README.md
+++ b/examples/tag-choice/README.md
@@ -1,0 +1,20 @@
+# Tag Choice
+
+This example implements a controlled, wrapping, multi-select tag group.
+
+## Behavior
+
+- Entries without a label are not rendered.
+- Selection is derived from the parent-owned array.
+- Tapping a tag reports its key and previous selected state.
+- Repeated taps toggle the entry without changing option order.
+- Reset restores the deterministic initial selection.
+
+## Commands
+
+```bash
+pnpm --filter @lynx-example/tag-choice dev
+pnpm --filter @lynx-example/tag-choice build
+```
+
+This example intentionally excludes generated API types, feedback submission, analytics, and network requests.

--- a/examples/tag-choice/lynx.config.ts
+++ b/examples/tag-choice/lynx.config.ts
@@ -1,0 +1,17 @@
+import { pluginQRCode } from "@lynx-js/qrcode-rsbuild-plugin";
+import { pluginReactLynx } from "@lynx-js/react-rsbuild-plugin";
+import { defineConfig } from "@lynx-js/rspeedy";
+
+export default defineConfig({
+  plugins: [
+    pluginQRCode(),
+    pluginReactLynx(),
+  ],
+  output: {
+    filename: "[name].[platform].bundle",
+  },
+  environments: {
+    web: {},
+    lynx: {},
+  },
+});

--- a/examples/tag-choice/package.json
+++ b/examples/tag-choice/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@lynx-example/tag-choice",
+  "version": "0.1.0",
+  "description": "An example shows how to build a multi-select tag choice group in Lynx",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lynx-family/lynx-examples.git",
+    "directory": "examples/tag-choice"
+  },
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
+  "type": "module",
+  "files": [
+    "dist/",
+    "src/",
+    "lynx.config.ts",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev",
+    "preview": "rspeedy preview"
+  },
+  "dependencies": {
+    "@lynx-js/react": "catalog:"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
+    "@lynx-js/react-rsbuild-plugin": "catalog:",
+    "@lynx-js/rspeedy": "catalog:",
+    "@lynx-js/types": "catalog:",
+    "@types/react": "^18.3.28",
+    "typescript": "~5.9.3"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/examples/tag-choice/src/App.css
+++ b/examples/tag-choice/src/App.css
@@ -1,0 +1,102 @@
+:root {
+  background-color: #fff7ed;
+}
+
+.Page {
+  min-height: 100vh;
+  padding: 48rpx 28rpx;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.Card {
+  width: 100%;
+  padding: 34rpx 24rpx 28rpx;
+  border-radius: 30rpx;
+  background-color: #ffffff;
+  box-shadow: 0 18rpx 50rpx rgba(119, 69, 19, 0.13);
+}
+
+.Eyebrow {
+  margin-left: 8rpx;
+  color: #ea580c;
+  font-size: 20rpx;
+  font-weight: 700;
+  letter-spacing: 2rpx;
+}
+
+.Title {
+  margin: 12rpx 8rpx 0;
+  color: #292018;
+  font-size: 42rpx;
+  font-weight: 700;
+}
+
+.Description {
+  margin: 12rpx 8rpx 20rpx;
+  color: #776b61;
+  font-size: 26rpx;
+  line-height: 38rpx;
+}
+
+.TagChoice {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  padding: 8rpx 16rpx 0;
+}
+
+.TagChoice__item {
+  margin: 16rpx 16rpx 0 0;
+  padding: 16rpx 14rpx;
+  border: 2rpx solid transparent;
+  border-radius: 16rpx;
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.TagChoice__item--selected {
+  border-color: #292018;
+  background-color: #ffedd5;
+}
+
+.TagChoice__text {
+  color: #292018;
+  font-size: 28rpx;
+  font-weight: 500;
+  line-height: 36rpx;
+}
+
+.Summary {
+  margin: 34rpx 8rpx 0;
+  padding-top: 24rpx;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  border-top: 2rpx solid #f2e8de;
+}
+
+.Summary__count {
+  color: #ea580c;
+  font-size: 34rpx;
+  font-weight: 700;
+}
+
+.Summary__label {
+  margin-left: 8rpx;
+  color: #776b61;
+  font-size: 24rpx;
+}
+
+.Reset {
+  margin-left: auto;
+  padding: 14rpx 20rpx;
+  border-radius: 18rpx;
+  background-color: #292018;
+}
+
+.Reset__text {
+  color: #ffffff;
+  font-size: 23rpx;
+  font-weight: 600;
+}

--- a/examples/tag-choice/src/App.tsx
+++ b/examples/tag-choice/src/App.tsx
@@ -1,0 +1,44 @@
+import { useState } from "@lynx-js/react";
+
+import "./App.css";
+import { TagChoice } from "./components/TagChoice.jsx";
+import { choices, initialChoices } from "./mockData.js";
+
+export function App() {
+  const [selectedChoices, setSelectedChoices] = useState(initialChoices);
+
+  const handleChoice = (choice: string, isSelected: boolean) => {
+    setSelectedChoices(
+      isSelected
+        ? selectedChoices.filter((item) => item !== choice)
+        : [...selectedChoices, choice],
+    );
+  };
+
+  return (
+    <page className="Page">
+      <view className="Card">
+        <text className="Eyebrow">FEEDBACK PATTERN</text>
+        <text className="Title">What worked well?</text>
+        <text className="Description">
+          Select any number of tags. Tap a selected tag again to remove it.
+        </text>
+        <TagChoice
+          choices={choices}
+          selectedChoices={selectedChoices}
+          onClickChoice={handleChoice}
+        />
+        <view className="Summary">
+          <text className="Summary__count">{selectedChoices.length}</text>
+          <text className="Summary__label">selected</text>
+          <view
+            className="Reset"
+            bindtap={() => setSelectedChoices(initialChoices)}
+          >
+            <text className="Reset__text">Reset choices</text>
+          </view>
+        </view>
+      </view>
+    </page>
+  );
+}

--- a/examples/tag-choice/src/components/TagChoice.tsx
+++ b/examples/tag-choice/src/components/TagChoice.tsx
@@ -1,0 +1,38 @@
+import type { Choice } from "../mockData.js";
+
+interface TagChoiceProps {
+  choices: Choice[];
+  selectedChoices?: string[];
+  onClickChoice?: (choice: string, isSelected: boolean) => void;
+}
+
+export function TagChoice({
+  choices,
+  selectedChoices = [],
+  onClickChoice,
+}: TagChoiceProps) {
+  return (
+    <view className="TagChoice">
+      {choices.map((choice) => {
+        const key = choice.label;
+        if (!key) {
+          return null;
+        }
+
+        const selected = selectedChoices.includes(key);
+        return (
+          <view
+            className={`TagChoice__item${selected ? " TagChoice__item--selected" : ""}`}
+            key={key}
+            bindtap={() => onClickChoice?.(key, selected)}
+            ignore-focus
+          >
+            <text className="TagChoice__text" ignore-focus>
+              {choice.text}
+            </text>
+          </view>
+        );
+      })}
+    </view>
+  );
+}

--- a/examples/tag-choice/src/index.tsx
+++ b/examples/tag-choice/src/index.tsx
@@ -1,0 +1,9 @@
+import { root } from "@lynx-js/react";
+
+import { App } from "./App.jsx";
+
+root.render(<App />);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/tag-choice/src/mockData.ts
+++ b/examples/tag-choice/src/mockData.ts
@@ -1,0 +1,15 @@
+export interface Choice {
+  label?: string;
+  text: string;
+}
+
+export const choices: Choice[] = [
+  { label: "clear", text: "Clear explanation" },
+  { label: "examples", text: "Useful examples" },
+  { label: "pace", text: "Good pacing" },
+  { label: "visual", text: "Strong visuals" },
+  { label: "practical", text: "Practical steps" },
+  { label: "", text: "Hidden fallback entry" },
+];
+
+export const initialChoices = ["clear", "practical"];

--- a/examples/tag-choice/src/rspeedy-env.d.ts
+++ b/examples/tag-choice/src/rspeedy-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@lynx-js/rspeedy/client" />

--- a/examples/tag-choice/tsconfig.json
+++ b/examples/tag-choice/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "@lynx-js/react",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "strict": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+  },
+  "exclude": [
+    "dist/",
+  ],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,6 +271,31 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
 
+  examples/adaptive-text:
+    dependencies:
+      '@lynx-js/react':
+        specifier: 'catalog:'
+        version: 0.123.0(@lynx-js/types@4.0.0)(@types/react@18.3.28)
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.6.0(@lynx-js/rspeedy@0.16.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.101.3))
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.18.0(@lynx-js/react@0.123.0(@lynx-js/types@4.0.0)(@types/react@18.3.28))(tslib@2.8.1)
+      '@lynx-js/rspeedy':
+        specifier: 'catalog:'
+        version: 0.16.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.101.3)
+      '@lynx-js/types':
+        specifier: 'catalog:'
+        version: 4.0.0
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+
   examples/animation:
     dependencies:
       '@lynx-js/react':
@@ -1444,6 +1469,31 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
 
+  examples/segmented-control:
+    dependencies:
+      '@lynx-js/react':
+        specifier: 'catalog:'
+        version: 0.123.0(@lynx-js/types@4.0.0)(@types/react@18.3.28)
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.6.0(@lynx-js/rspeedy@0.16.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.101.3))
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.18.0(@lynx-js/react@0.123.0(@lynx-js/types@4.0.0)(@types/react@18.3.28))(tslib@2.8.1)
+      '@lynx-js/rspeedy':
+        specifier: 'catalog:'
+        version: 0.16.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.101.3)
+      '@lynx-js/types':
+        specifier: 'catalog:'
+        version: 4.0.0
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+
   examples/svg:
     dependencies:
       '@lynx-js/react':
@@ -1493,6 +1543,31 @@ importers:
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.6(core-js@3.47.0))
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+
+  examples/tag-choice:
+    dependencies:
+      '@lynx-js/react':
+        specifier: 'catalog:'
+        version: 0.123.0(@lynx-js/types@4.0.0)(@types/react@18.3.28)
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.6.0(@lynx-js/rspeedy@0.16.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.101.3))
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.18.0(@lynx-js/react@0.123.0(@lynx-js/types@4.0.0)(@types/react@18.3.28))(tslib@2.8.1)
+      '@lynx-js/rspeedy':
+        specifier: 'catalog:'
+        version: 0.16.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.4(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.101.3)
+      '@lynx-js/types':
+        specifier: 'catalog:'
+        version: 4.0.0
       '@types/react':
         specifier: ^18.3.28
         version: 18.3.28


### PR DESCRIPTION
## Summary

- Add `examples/segmented-control/` for controlled single-choice selection.
- Add `examples/tag-choice/` for controlled wrapping multi-select choices.
- Add `examples/adaptive-text/` for layout-driven font-size reduction.
- Preserve the selected source behavior while replacing business boundaries with deterministic mock data and public `@lynx-js/*` packages.

## Validation

- `pnpm --filter @lynx-example/segmented-control run build`: pass
- `pnpm --filter @lynx-example/tag-choice run build`: pass
- `pnpm --filter @lynx-example/adaptive-text run build`: pass
- `pnpm dprint check`: pass
- `pnpm meta-updater --test`: pass
- `pnpm changeset status --verbose`: pass
- Sensitive content and path scans: zero matches
- Android Lynx Explorer: all three examples render successfully
- Interaction checks: segment selection changed to `month`; tag selection increased from 2 to 3; adaptive long text resolved to `28rpx`

## Risk

- Product navigation, analytics, network requests, private UI packages, generated business types, remote fonts, and host-specific services are intentionally excluded.
- No behavioral simplifications were required for the selected capability slices.