### PR TITLE
feat(vanilla): shared-context counter demo (cross-card module sharing)

### DIFF
--- a/.changeset/vanilla-shared-context-demo.md
+++ b/.changeset/vanilla-shared-context-demo.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/vanilla": patch
+---
+
+Add a shared-context counter demo: two pages that opt into cross-card module sharing via the `enableSharedContextModules` page config and observe one `lynx.requireModuleAsync` module instance when opened in the same LynxGroup (`group=<name>` schema param in Lynx Explorer).

--- a/examples/vanilla/lynx.config.ts
+++ b/examples/vanilla/lynx.config.ts
@@ -10,6 +10,10 @@ import { pluginVanillaTemplateWebpack } from "./plugin.js";
 
 const projectRoot = path.dirname(fileURLToPath(import.meta.url));
 
+// `public/shared-state.js` is served by the dev server at the root (and
+// copied into dist on build) — Rsbuild's default public dir. The shared
+// pages reach it via `__webpack_public_path__`, which rspeedy dev
+// normalizes to `http://<host>:<port>/` with the actual port.
 export default defineConfig({
   dev: {
     hmr: false,
@@ -22,6 +26,8 @@ export default defineConfig({
       "product-card": path.join(projectRoot, "src/product-card/main-thread.ts"),
       todolist: path.join(projectRoot, "src/todolist/main-thread.ts"),
       "weather-card": path.join(projectRoot, "src/weather-card/main-thread.ts"),
+      "shared-page-a": path.join(projectRoot, "src/shared-page-a/main-thread.ts"),
+      "shared-page-b": path.join(projectRoot, "src/shared-page-b/main-thread.ts"),
     },
   },
   output: {

--- a/examples/vanilla/plugin.ts
+++ b/examples/vanilla/plugin.ts
@@ -117,6 +117,14 @@ export function pluginVanillaTemplateWebpack(): RsbuildPlugin {
                 // schema, so set it on the page config directly.
                 args.encodeData.sourceContent.config.enableEventHandleRefactor = true;
 
+                // Opt the shared-counter demo pages into cross-card module
+                // sharing: cards in one shared-context LynxGroup receive the
+                // same `lynx.requireModuleAsync` module instance. Off for all
+                // other pages (engine default).
+                if (pageName.startsWith("shared-page-")) {
+                  args.encodeData.sourceContent.config.enableSharedContextModules = true;
+                }
+
                 args.encodeData.manifest = backgroundAsset
                   ? {
                     [backgroundAsset.name]: backgroundAsset.source

--- a/examples/vanilla/public/shared-state.js
+++ b/examples/vanilla/public/shared-state.js
@@ -1,0 +1,33 @@
+// A hand-written module in the Lynx loadScript (AMD) format — the same shape
+// the runtime wrapper emits — loadable via `lynx.requireModuleAsync`.
+//
+// No marker needed: lynx-core shares plain modules per JS context by default,
+// so when multiple pages run in one shared-context LynxGroup they observe the
+// same exports (and thus the same `state`). No bundler or toolchain
+// involvement.
+(function() {
+  "use strict";
+  var g = globalThis;
+  function init(injected) {
+    g.__bundle__holder = void 0;
+    var tt = injected.tt;
+    tt.define("vanilla-shared-state.js", function(require, module, exports) {
+      var state = { count: 0 };
+      exports.state = state;
+      exports.bump = function(page) {
+        state.count += 1;
+        console.info(
+          "[vanilla-shared] bump from " + page + ", count = " + state.count,
+        );
+        return state.count;
+      };
+    });
+    return tt.require("vanilla-shared-state.js");
+  }
+  if (g && g.bundleSupportLoadScript) {
+    var holder = { init: init };
+    g.__bundle__holder = holder;
+    return holder;
+  }
+  return init({ tt: g.tt });
+})();

--- a/examples/vanilla/src/shared-page-a/background.ts
+++ b/examples/vanilla/src/shared-page-a/background.ts
@@ -1,0 +1,54 @@
+import { setData } from "../common/background/data.js";
+import { setBackgroundEventHandler } from "../common/background/event.js";
+import { setupBackground } from "../common/background/setup.js";
+
+setupBackground();
+
+// `public/shared-state.js`, served by the dev server. The webpack public
+// path is normalized by rspeedy dev to `http://<host>:<port>/` (device
+// reachable, actual port), so the URL needs no config-time baking.
+// lynx-core shares plain modules per JS context by default, so when pages
+// run in one shared-context LynxGroup, lynx.requireModuleAsync hands every
+// page the same module instance.
+declare let __webpack_public_path__: string;
+const SHARED_STATE_URL = `${__webpack_public_path__}shared-state.js`;
+const PAGE = "page-a";
+
+type SharedState = {
+  state: { count: number };
+  bump: (page: string) => number;
+};
+
+let shared: SharedState | undefined;
+
+lynx.requireModuleAsync<SharedState>(SHARED_STATE_URL, (error, mod) => {
+  if (error || !mod) {
+    console.error(
+      `[vanilla-shared] load failed: ${error?.message ?? "no exports"}`,
+    );
+    // Make the failure visible: a page whose shared module failed to load
+    // would otherwise look fine but ignore every tap.
+    setData({ count: "ERR" });
+    return;
+  }
+  shared = mod;
+  // Debug path: bump once on load, so the counter is alive (and the sharing
+  // observable) without any human interaction.
+  setData({ count: mod.bump(PAGE) });
+});
+
+setBackgroundEventHandler((handlerName) => {
+  if (!shared) return false;
+  if (handlerName === "bump") {
+    // Human path: tap +1 — increments the module instance shared with the
+    // other pages in the group.
+    setData({ count: shared.bump(PAGE) });
+    return true;
+  }
+  if (handlerName === "sync") {
+    // Read-only refresh: shows increments made by the other pages.
+    setData({ count: shared.state.count });
+    return true;
+  }
+  return false;
+});

--- a/examples/vanilla/src/shared-page-a/main-thread.ts
+++ b/examples/vanilla/src/shared-page-a/main-thread.ts
@@ -1,0 +1,52 @@
+import type { RawTextElementRef } from "@lynx-js/type-element-api";
+
+import { createPage, createText, createView } from "../common/main-thread/element.js";
+import { bindBackgroundEvent } from "../common/main-thread/event.js";
+import { setupMainThread } from "../common/main-thread/setup.js";
+
+const { page, pageId } = createPage("page");
+
+let countRaw: RawTextElementRef | undefined;
+
+function renderPage(): void {
+  const badge = createText(pageId, "badge", "PAGE A");
+  __AppendElement(page, badge.text);
+
+  const title = createText(pageId, "title", "Shared Counter");
+  __AppendElement(page, title.text);
+
+  const hint = createText(
+    pageId,
+    "hint",
+    "one module instance, shared by every page in the group",
+  );
+  __AppendElement(page, hint.text);
+
+  const counter = createText(pageId, "counter", "…");
+  countRaw = counter.raw;
+  __AppendElement(page, counter.text);
+
+  const bump = createView(pageId, "button");
+  bindBackgroundEvent(bump, "tap", "bump");
+  __AppendElement(bump, createText(pageId, "button-label", "+1").text);
+  __AppendElement(page, bump);
+
+  const sync = createView(pageId, "button button-secondary");
+  bindBackgroundEvent(sync, "tap", "sync");
+  __AppendElement(
+    sync,
+    createText(pageId, "button-label button-label-secondary", "Sync").text,
+  );
+  __AppendElement(page, sync);
+}
+
+function updatePage(data: Record<string, unknown>): void {
+  if (!countRaw || typeof data?.["count"] === "undefined") return;
+  __SetAttribute(countRaw, "text", String(data["count"]));
+  __FlushElementTree();
+}
+
+setupMainThread({
+  renderPage,
+  updatePage,
+});

--- a/examples/vanilla/src/shared-page-a/style.css
+++ b/examples/vanilla/src/shared-page-a/style.css
@@ -1,0 +1,73 @@
+:root {
+  background-color: #101114;
+}
+
+text {
+  color: #ffffff;
+}
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.badge {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 4px;
+  color: #ff6a54;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid #3a2320;
+  background-color: #1c1412;
+}
+
+.title {
+  margin-top: 14px;
+  font-size: 34px;
+  font-weight: 700;
+}
+
+.hint {
+  margin-top: 8px;
+  font-size: 13px;
+  color: #9aa0a6;
+}
+
+.counter {
+  margin-top: 18px;
+  font-size: 96px;
+  font-weight: 700;
+  color: #ff351a;
+}
+
+.button {
+  margin-top: 26px;
+  width: 220px;
+  padding: 16px 0;
+  border-radius: 12px;
+  background-color: #ff351a;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.button-label {
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.button-secondary {
+  margin-top: 14px;
+  background-color: transparent;
+  border: 1px solid #34373d;
+}
+
+.button-label-secondary {
+  font-size: 18px;
+  font-weight: 600;
+  color: #c8cdd3;
+}

--- a/examples/vanilla/src/shared-page-b/background.ts
+++ b/examples/vanilla/src/shared-page-b/background.ts
@@ -1,0 +1,54 @@
+import { setData } from "../common/background/data.js";
+import { setBackgroundEventHandler } from "../common/background/event.js";
+import { setupBackground } from "../common/background/setup.js";
+
+setupBackground();
+
+// `public/shared-state.js`, served by the dev server. The webpack public
+// path is normalized by rspeedy dev to `http://<host>:<port>/` (device
+// reachable, actual port), so the URL needs no config-time baking.
+// lynx-core shares plain modules per JS context by default, so when pages
+// run in one shared-context LynxGroup, lynx.requireModuleAsync hands every
+// page the same module instance.
+declare let __webpack_public_path__: string;
+const SHARED_STATE_URL = `${__webpack_public_path__}shared-state.js`;
+const PAGE = "page-b";
+
+type SharedState = {
+  state: { count: number };
+  bump: (page: string) => number;
+};
+
+let shared: SharedState | undefined;
+
+lynx.requireModuleAsync<SharedState>(SHARED_STATE_URL, (error, mod) => {
+  if (error || !mod) {
+    console.error(
+      `[vanilla-shared] load failed: ${error?.message ?? "no exports"}`,
+    );
+    // Make the failure visible: a page whose shared module failed to load
+    // would otherwise look fine but ignore every tap.
+    setData({ count: "ERR" });
+    return;
+  }
+  shared = mod;
+  // Debug path: bump once on load, so the counter is alive (and the sharing
+  // observable) without any human interaction.
+  setData({ count: mod.bump(PAGE) });
+});
+
+setBackgroundEventHandler((handlerName) => {
+  if (!shared) return false;
+  if (handlerName === "bump") {
+    // Human path: tap +1 — increments the module instance shared with the
+    // other pages in the group.
+    setData({ count: shared.bump(PAGE) });
+    return true;
+  }
+  if (handlerName === "sync") {
+    // Read-only refresh: shows increments made by the other pages.
+    setData({ count: shared.state.count });
+    return true;
+  }
+  return false;
+});

--- a/examples/vanilla/src/shared-page-b/main-thread.ts
+++ b/examples/vanilla/src/shared-page-b/main-thread.ts
@@ -1,0 +1,52 @@
+import type { RawTextElementRef } from "@lynx-js/type-element-api";
+
+import { createPage, createText, createView } from "../common/main-thread/element.js";
+import { bindBackgroundEvent } from "../common/main-thread/event.js";
+import { setupMainThread } from "../common/main-thread/setup.js";
+
+const { page, pageId } = createPage("page");
+
+let countRaw: RawTextElementRef | undefined;
+
+function renderPage(): void {
+  const badge = createText(pageId, "badge", "PAGE B");
+  __AppendElement(page, badge.text);
+
+  const title = createText(pageId, "title", "Shared Counter");
+  __AppendElement(page, title.text);
+
+  const hint = createText(
+    pageId,
+    "hint",
+    "one module instance, shared by every page in the group",
+  );
+  __AppendElement(page, hint.text);
+
+  const counter = createText(pageId, "counter", "…");
+  countRaw = counter.raw;
+  __AppendElement(page, counter.text);
+
+  const bump = createView(pageId, "button");
+  bindBackgroundEvent(bump, "tap", "bump");
+  __AppendElement(bump, createText(pageId, "button-label", "+1").text);
+  __AppendElement(page, bump);
+
+  const sync = createView(pageId, "button button-secondary");
+  bindBackgroundEvent(sync, "tap", "sync");
+  __AppendElement(
+    sync,
+    createText(pageId, "button-label button-label-secondary", "Sync").text,
+  );
+  __AppendElement(page, sync);
+}
+
+function updatePage(data: Record<string, unknown>): void {
+  if (!countRaw || typeof data?.["count"] === "undefined") return;
+  __SetAttribute(countRaw, "text", String(data["count"]));
+  __FlushElementTree();
+}
+
+setupMainThread({
+  renderPage,
+  updatePage,
+});

--- a/examples/vanilla/src/shared-page-b/style.css
+++ b/examples/vanilla/src/shared-page-b/style.css
@@ -1,0 +1,73 @@
+:root {
+  background-color: #101114;
+}
+
+text {
+  color: #ffffff;
+}
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.badge {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 4px;
+  color: #6aa8ff;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid #20293a;
+  background-color: #12161c;
+}
+
+.title {
+  margin-top: 14px;
+  font-size: 34px;
+  font-weight: 700;
+}
+
+.hint {
+  margin-top: 8px;
+  font-size: 13px;
+  color: #9aa0a6;
+}
+
+.counter {
+  margin-top: 18px;
+  font-size: 96px;
+  font-weight: 700;
+  color: #2f7bff;
+}
+
+.button {
+  margin-top: 26px;
+  width: 220px;
+  padding: 16px 0;
+  border-radius: 12px;
+  background-color: #2f7bff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.button-label {
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.button-secondary {
+  margin-top: 14px;
+  background-color: transparent;
+  border: 1px solid #34373d;
+}
+
+.button-label-secondary {
+  font-size: 18px;
+  font-weight: 600;
+  color: #c8cdd3;
+}


### PR DESCRIPTION
## Summary

Two demo pages (`shared-page-a` / `shared-page-b`) showing cross-card module sharing in a shared-context LynxGroup:

- Both pages opt in via the `enableSharedContextModules` page config (set in `plugin.ts` beforeEncode; engine default is off) — requires a Lynx engine with lynx-family/lynx#8287.
- `public/shared-state.js` is a hand-written AMD (`bundleSupportLoadScript`) module served by the dev server; pages resolve it at runtime from `__webpack_public_path__`, which rspeedy dev normalizes to `http://<host>:<port>/`.
- Open both pages with the same `group=<name>` schema param in Lynx Explorer: page A loads → counter 1, page B loads → counter 2 (same module instance), `+1` taps keep incrementing the shared count from either page; `Sync` pulls the latest value.
- Without the config (or without a group), each page evaluates its own copy and both show 1.

## Verification

On a Pixel 4 XL running a from-source Explorer with lynx-family/lynx#8287:

- config on for both pages, same group → counts 1, 2, then 3 after one tap (one instance, monotonic across cards)
- config on for A only, same group → both show 1 (per-card opt-in; default off)