### PR TITLE
fix(gallery): let the list fill its wrapper

### DIFF
--- a/.changeset/gallery-list-fills-wrapper.md
+++ b/.changeset/gallery-list-fills-wrapper.md
@@ -1,0 +1,7 @@
+---
+"@lynx-example/gallery": patch
+---
+
+Let the gallery list fill its wrapper instead of leaving a 48px black band.
+
+`.list` was `height: calc(100% - 48px)` inside a black `.gallery-wrapper`, and every scrollbar step derived its viewport from `SystemInfo.pixelHeight / SystemInfo.pixelRatio - 48`. That 48 is Lynx Explorer's title bar, but `100%` is already the page area below it, so the example subtracted it twice — leaving the band on Lynx for Web, in Explorer's fullscreen mode, and under the title bar itself. The scrollbar now takes its viewport from `event.detail.listHeight`, the list's own box.

--- a/examples/Gallery/src/AddNiceScrollbar/Gallery.tsx
+++ b/examples/Gallery/src/AddNiceScrollbar/Gallery.tsx
@@ -1,6 +1,6 @@
 import "../index.scss";
 import { useEffect, useRef } from "@lynx-js/react";
-import type { ScrollEvent } from "@lynx-js/types";
+import type { ListScrollEvent } from "@lynx-js/types";
 import type { NodesRef } from "@lynx-js/types";
 import LikeImageCard from "../Components/LikeImageCard.jsx";
 import type { Picture } from "../Pictures/furnitures/furnituresPictures.jsx";
@@ -11,10 +11,14 @@ export const Gallery = (props: { pictureData: Picture[] }) => {
   const { pictureData } = props;
   const scrollbarRef = useRef<NiceScrollbarRef>(null);
 
-  const onScroll = (event: ScrollEvent) => {
+  const onScroll = (event: ListScrollEvent) => {
+    // `listHeight` is the list's own box. Native engines report it; Lynx for
+    // Web does not, and there the list fills the page, so the page height is
+    // the same number.
     scrollbarRef.current?.adjustScrollbar(
       event.detail.scrollTop,
       event.detail.scrollHeight,
+      event.detail.listHeight || SystemInfo.pixelHeight / SystemInfo.pixelRatio,
     );
   };
 

--- a/examples/Gallery/src/AddNiceScrollbar/NiceScrollbar.tsx
+++ b/examples/Gallery/src/AddNiceScrollbar/NiceScrollbar.tsx
@@ -2,15 +2,14 @@ import "../index.scss";
 import { forwardRef, useImperativeHandle, useState } from "@lynx-js/react";
 
 export interface NiceScrollbarRef {
-  adjustScrollbar: (scrollTop: number, scrollHeight: number) => void;
+  adjustScrollbar: (scrollTop: number, scrollHeight: number, listHeight: number) => void;
 }
 
 export const NiceScrollbar = forwardRef((_, ref) => {
   const [scrollbarHeight, setScrollbarHeight] = useState(0);
   const [scrollbarTop, setScrollbarTop] = useState(0);
 
-  const adjustScrollbar = (scrollTop: number, scrollHeight: number) => {
-    const listHeight = SystemInfo.pixelHeight / SystemInfo.pixelRatio - 48;
+  const adjustScrollbar = (scrollTop: number, scrollHeight: number, listHeight: number) => {
     const scrollbarHeight = listHeight * (listHeight / scrollHeight);
     const scrollbarTop = listHeight * (scrollTop / scrollHeight);
     setScrollbarHeight(scrollbarHeight);

--- a/examples/Gallery/src/GalleryComplete/Gallery.tsx
+++ b/examples/Gallery/src/GalleryComplete/Gallery.tsx
@@ -1,6 +1,6 @@
 import "../index.scss";
 import { useEffect, useMainThreadRef, useRef } from "@lynx-js/react";
-import { MainThread, type NodesRef, type ScrollEvent } from "@lynx-js/types";
+import { type ListScrollEvent, MainThread, type NodesRef } from "@lynx-js/types";
 import LikeImageCard from "../Components/LikeImageCard.jsx";
 import type { Picture } from "../Pictures/furnitures/furnituresPictures.jsx";
 import { calculateEstimatedSize } from "../utils.jsx";
@@ -13,9 +13,13 @@ export const Gallery = (
   const scrollbarMTSRef = useMainThreadRef<MainThread.Element>(null);
   const galleryRef = useRef<NodesRef>(null);
 
-  const onScrollMTS = (event: ScrollEvent) => {
+  const onScrollMTS = (event: ListScrollEvent) => {
     "main thread";
-    adjustScrollbarMTS(event.detail.scrollTop, event.detail.scrollHeight, scrollbarMTSRef);
+    // `listHeight` is the list's own box. Native engines report it; Lynx for
+    // Web does not, and there the list fills the page, so the page height is
+    // the same number.
+    const listHeight = event.detail.listHeight || SystemInfo.pixelHeight / SystemInfo.pixelRatio;
+    adjustScrollbarMTS(event.detail.scrollTop, event.detail.scrollHeight, listHeight, scrollbarMTSRef);
   };
 
   useEffect(() => {

--- a/examples/Gallery/src/GalleryComplete/NiceScrollbarMTS.tsx
+++ b/examples/Gallery/src/GalleryComplete/NiceScrollbarMTS.tsx
@@ -2,9 +2,13 @@ import "../index.scss";
 import { type MainThreadRef, type RefObject } from "@lynx-js/react";
 import { MainThread } from "@lynx-js/types";
 
-export const adjustScrollbarMTS = (scrollTop: number, scrollHeight: number, ref: RefObject<MainThread.Element>) => {
+export const adjustScrollbarMTS = (
+  scrollTop: number,
+  scrollHeight: number,
+  listHeight: number,
+  ref: RefObject<MainThread.Element>,
+) => {
   "main thread";
-  const listHeight = SystemInfo.pixelHeight / SystemInfo.pixelRatio - 48;
   const scrollbarHeight = listHeight * (listHeight / scrollHeight);
   const scrollbarTop = listHeight * (scrollTop / scrollHeight);
   ref.current?.setStyleProperties({

--- a/examples/Gallery/src/ScrollbarCompare/Gallery.tsx
+++ b/examples/Gallery/src/ScrollbarCompare/Gallery.tsx
@@ -1,6 +1,6 @@
 import "../index.scss";
 import { useEffect, useMainThreadRef, useRef } from "@lynx-js/react";
-import { MainThread, type ScrollEvent } from "@lynx-js/types";
+import { type ListScrollEvent, MainThread } from "@lynx-js/types";
 import type { NodesRef } from "@lynx-js/types";
 import LikeImageCard from "../Components/LikeImageCard.jsx";
 import type { Picture } from "../Pictures/furnitures/furnituresPictures.jsx";
@@ -14,19 +14,21 @@ export const Gallery = (props: { pictureData: Picture[] }) => {
   const scrollbarMTSRef = useMainThreadRef<MainThread.Element>(null);
   const galleryRef = useRef<NodesRef>(null);
 
-  const onScrollMTS = (event: ScrollEvent) => {
+  const onScrollMTS = (event: ListScrollEvent) => {
     "main thread";
     adjustScrollbarMTS(
       event.detail.scrollTop,
       event.detail.scrollHeight,
+      event.detail.listHeight || SystemInfo.pixelHeight / SystemInfo.pixelRatio,
       scrollbarMTSRef,
     );
   };
 
-  const onScroll = (event: ScrollEvent) => {
+  const onScroll = (event: ListScrollEvent) => {
     scrollbarRef.current?.adjustScrollbar(
       event.detail.scrollTop,
       event.detail.scrollHeight,
+      event.detail.listHeight || SystemInfo.pixelHeight / SystemInfo.pixelRatio,
     );
   };
 

--- a/examples/Gallery/src/ScrollbarCompare/NiceScrollbar.tsx
+++ b/examples/Gallery/src/ScrollbarCompare/NiceScrollbar.tsx
@@ -2,7 +2,7 @@ import "../index.scss";
 import { forwardRef, useImperativeHandle, useState } from "@lynx-js/react";
 
 export interface NiceScrollbarRef {
-  adjustScrollbar: (scrollTop: number, scrollHeight: number) => void;
+  adjustScrollbar: (scrollTop: number, scrollHeight: number, listHeight: number) => void;
 }
 
 export const NiceScrollbar = forwardRef((_, ref) => {

--- a/examples/Gallery/src/ScrollbarCompare/NiceScrollbarMTS.tsx
+++ b/examples/Gallery/src/ScrollbarCompare/NiceScrollbarMTS.tsx
@@ -2,9 +2,13 @@ import "../index.scss";
 import { type MainThreadRef, type RefObject } from "@lynx-js/react";
 import { MainThread } from "@lynx-js/types";
 
-export const adjustScrollbarMTS = (scrollTop: number, scrollHeight: number, ref: RefObject<MainThread.Element>) => {
+export const adjustScrollbarMTS = (
+  scrollTop: number,
+  scrollHeight: number,
+  listHeight: number,
+  ref: RefObject<MainThread.Element>,
+) => {
   "main thread";
-  const listHeight = SystemInfo.pixelHeight / SystemInfo.pixelRatio;
   const scrollbarHeight = listHeight * (listHeight / scrollHeight);
   const scrollbarTop = listHeight * (scrollTop / scrollHeight);
   ref.current?.setStyleProperties({

--- a/examples/Gallery/src/index.scss
+++ b/examples/Gallery/src/index.scss
@@ -53,7 +53,7 @@
   padding-bottom: 20px;
   padding-left: 20px;
   padding-right: 20px;
-  height: calc(100% - 48px);
+  height: 100%;
   list-main-axis-gap: 10px;
   list-cross-axis-gap: 10px;
 }


### PR DESCRIPTION
## What

The gallery leaves a 48px black band under the grid, in every environment.

## Why

`.list` is `height: calc(100% - 48px)` inside a `.gallery-wrapper` that is
`height: 100%` with a black background, and every scrollbar step derives its
viewport from `SystemInfo.pixelHeight / SystemInfo.pixelRatio - 48`.

That 48 is **Lynx Explorer's title bar** — this tutorial's QR schema turns it on
with `?bar_color=000000&back_button_style=dark&title=Popular Furniture`. But
`100%` is already the page area *below* that bar, so the example subtracts it a
second time. And a shorter list would not move content out from under a *top*
bar anyway, so the 48px only ever appears as dead space at the bottom.

The result is a band in all three environments:

- **Lynx for Web**, where there is no title bar at all;
- **Explorer in fullscreen** (`?fullscreen=true`);
- and **under the title bar itself**.

`calc(100% - 48px)` has been here since the initial commit and no 48px header
element was ever rendered.

## How

- `.list` fills its wrapper (`height: 100%`).
- Every scrollbar step takes its viewport from `event.detail.listHeight` — the
  list's own box — instead of guessing from the screen. The three list scroll
  handlers are typed `ListScrollEvent` accordingly; the generic `ScrollEvent`
  carries `BaseScrollInfo`, which has no `listHeight`.
- Lynx for Web reports `listHeight` as `0`, so the page height is the fallback
  (`||`, not `??`) — the same number once the list fills the page.

This touches `AddNiceScrollbar`, `ScrollbarCompare` and `GalleryComplete`, so the
tutorial steps stay consistent with each other.

## Verification

`rspeedy build` passes for both the `web` and `lynx` environments.

Measured through `@lynx-js/web-core` in headless Chromium, `GalleryComplete`:

| | before | after |
| --- | --- | --- |
| `.gallery-wrapper` height | 700 | 700 |
| `.list` height | 652 | **700** |
| band at bottom | **48px** | **0** |
| scrollbar inline style | `height: 60.1px; top: 51.5px` | `height: 69.3px; top: 53.4px` |

The scrollbar grows because its viewport is now the full 700px list rather than
652px, which is the point of the change.

> Note: an intermediate version used `??` instead of `||` and silently collapsed
> the scrollbar to zero height on Web, because `listHeight` is `0` there rather
> than `undefined`. The `||` is deliberate.

## Related

The same defect is inherited by the Vue Lynx and Octane ports of this tutorial,
and `lynx-website` quotes the CSS literally in `docs/{en,zh}/learn/gallery.mdx`.
Companion PRs follow.
