### PR TITLE
ci: use Changesets pack and publish actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,25 +7,25 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  release:
-    name: Release
+  select-mode:
+    name: Select Mode
     runs-on: ubuntu-latest
-    environment: npm
-    concurrency:
-      group: ${{ github.workflow }}
-      cancel-in-progress: false
+    outputs:
+      mode: ${{ steps.select-mode.outputs.mode }}
+      publish-plan-artifact-id: ${{ steps.select-mode.outputs.publish-plan-artifact-id }}
     permissions:
-      contents: write
-      pull-requests: write
-      id-token: write
+      contents: read
 
     steps:
       - name: Checkout Repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          # This makes Actions fetch all Git history so that Changesets can generate changelogs
-          fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -37,11 +37,110 @@ jobs:
         run: |
           npm i -g corepack@latest --force
           corepack enable
-          pnpm install
+          pnpm install --frozen-lockfile
 
-      - name: Create Release Pull Request or Publish to npm
-        id: changesets
-        uses: changesets/action@v2
+      - name: Select Changesets Mode
+        id: select-mode
+        uses: changesets/action/select-mode@22ccf9aa43179fe9e27dc62e575971d28cce197c # v2
+
+  version:
+    name: Version Packages
+    if: needs.select-mode.outputs.mode == 'version'
+    needs: select-mode
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          publish-script: pnpm run release
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Install Dependencies
+        run: |
+          npm i -g corepack@latest --force
+          corepack enable
+          pnpm install --frozen-lockfile
+
+      - name: Version Packages
+        uses: changesets/action/version@22ccf9aa43179fe9e27dc62e575971d28cce197c # v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  pack:
+    name: Pack Packages
+    if: needs.select-mode.outputs.mode == 'publish'
+    needs: select-mode
+    runs-on: ubuntu-latest
+    outputs:
+      pack-dir-artifact-id: ${{ steps.pack.outputs.pack-dir-artifact-id }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Install Dependencies
+        run: |
+          npm i -g corepack@latest --force
+          corepack enable
+          pnpm install --frozen-lockfile
+
+      - name: Build Packages
+        run: pnpm run build
+
+      - name: Pack Packages
+        id: pack
+        uses: changesets/action/pack@22ccf9aa43179fe9e27dc62e575971d28cce197c # v2
+        with:
+          publish-plan-artifact-id: ${{ needs.select-mode.outputs.publish-plan-artifact-id }}
+
+  publish:
+    name: Publish Packages
+    needs: pack
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Install Dependencies
+        run: |
+          npm i -g corepack@latest --force
+          corepack enable
+          pnpm install --frozen-lockfile
+
+      - name: Publish Packages
+        uses: changesets/action/publish@22ccf9aa43179fe9e27dc62e575971d28cce197c # v2
+        with:
+          pack-dir-artifact-id: ${{ needs.pack.outputs.pack-dir-artifact-id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@
 
 - Changesets are required for publishable package changes; follow existing `.changeset/*.md` format.
 - `.changeset/config.json` tracks changes under `src/**`, `lynx.config.ts`, and `lynx.config.mjs`; edits there are what CI uses for change detection.
-- Release flow on `main` runs `pnpm run release` (`build` then `changeset publish`).
+- Release flow on `main` uses Changesets Action v2 sub-actions: it creates or updates the version PR when changesets exist; after that PR is merged, it builds and packs publishable packages before publishing the tarballs with npm Trusted Publishing.
 
 ## Repo-specific gotchas
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "author": "Lynx Authors",
   "scripts": {
     "build": "EXPERIMENTAL_USE_WEB_BINARY_TEMPLATE=false turbo run build",
-    "prepare": "husky",
-    "release": "npm run build && pnpm changeset publish"
+    "prepare": "husky"
   },
   "nano-staged": {
     "*.{css,scss,js,jsx,ts,tsx,mjs,cjs,json,jsonc,md}": [


### PR DESCRIPTION
## Summary

- replace the combined Changesets action with the `select-mode` and `version` sub-actions
- build and pack publishable packages in a least-privileged job, then publish the exact tarball artifact in a separate job
- scope the `npm` environment and `id-token: write` permission to the publish job only
- pin Changesets sub-actions, disable persisted checkout credentials, and use frozen installs
- remove the obsolete direct-release script and update `AGENTS.md`

This follows the Changesets v3 Trusted Publishing workflow: https://changesets.dev/guide/automating#trusted-publishing

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm dprint check`
- `pnpm meta-updater --test`
- `pnpm changeset status --verbose --since upstream/main`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release.yml`
- `pnpm run build` (71/71 tasks passed)
- generated the live publish plan and packed all five planned packages into tarballs with integrity metadata and built `dist` files

No changeset is needed because this only changes root tooling, documentation, and the release workflow.

## Existing npm prerequisite

The current publish plan still contains these packages:

- `@lynx-example/css-global@0.1.0`
- `@lynx-example/css-modules@0.1.0`
- `@lynx-example/css-postcss@0.1.0`
- `@lynx-example/css-preprocessors@0.1.0`
- `@lynx-example/vanilla@0.1.3`

The two latest release runs already fail with npm `E404` for these package names, including https://github.com/lynx-family/lynx-examples/actions/runs/31599664677. They still need their npm first-publish / Trusted Publisher setup for `release.yml` and the `npm` environment. The new artifact pipeline preserves the same publish plan and does not bypass that registry prerequisite.