### PR TITLE
feat: add text composition example

### DIFF
--- a/.changeset/text-composition-example.md
+++ b/.changeset/text-composition-example.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/text-composition": minor
+---
+
+Add a text-composition example with 24 independently navigable source-parity cases covering natural wrapping, inline text/image/view content, truncation, events, bidirectional text, a development guide, and a reusable coding skill.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repository is intended to showcase examples of Lynx.
   - [`list`]: An example shows how to use reusable and scrollable container
   - [`scroll-view`]: An example shows how to use scrollable container
   - [`text`]: An example shows how to use text and inline-text
+  - [`text-composition`]: An example shows how to compose naturally wrapping text with inline text, images, views, and truncation
   - [`view`]: An example shows how to use view
   - [`frame`]: An example shows how to use frame
   - [`page`]: An example shows how to use page in Lynx
@@ -118,6 +119,7 @@ This repository is intended to showcase examples of Lynx.
 [`tailwindcss`]: ./examples/tailwindcss
 [`tanstack-router`]: ./examples/tanstack-router
 [`text`]: ./examples/text
+[`text-composition`]: ./examples/text-composition
 [`webview`]: ./examples/webview
 [`webassembly`]: ./examples/webassembly
 [`textarea`]: ./examples/textarea

--- a/examples/text-composition/CHANGELOG.md
+++ b/examples/text-composition/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @lynx-example/text-composition
+
+## 0.1.0
+
+### Minor Changes
+
+- Add a ReactLynx text-composition example with 24 independently navigable text-layout cases, a development guide, and a reusable coding skill.

--- a/examples/text-composition/README.md
+++ b/examples/text-composition/README.md
@@ -1,0 +1,190 @@
+# Lynx Text Composition Guide
+
+This example migrates 24 top-level legacy text platform cases into 24 independently navigable ReactLynx pages. Each page represents one source case and preserves its comparison matrix, state transitions, and event entry points.
+
+The central rule is simple: one outer `<text>` should own the text layout context for a continuous passage that needs shared measurement and natural wrapping.
+
+## Run the example
+
+```bash
+pnpm --filter @lynx-example/text-composition run dev
+pnpm --filter @lynx-example/text-composition run build
+```
+
+Main files:
+
+- `src/components/TextCompositionArticle.tsx`: production-oriented composition.
+- `src/components/CaseGallery.tsx`: previous/next navigation and isolated screenshot surface for 24 cases.
+- `src/cases/registry.tsx`: the one-to-one source case registry.
+- `src/cases/*Cases.tsx`: complete foundation, inline, truncation, and layout cases.
+- `src/App.css`: paragraph properties, inline alignment, and regression styles.
+- `src/mockData.ts`: deterministic copy and a data-URI inline image with no network request.
+- `SKILL.md`: reusable implementation and review workflow for coding agents.
+
+Use the Previous and Next controls to switch cases. The `01 / 24` progress label and source directory name identify each screenshot. Switching cases also resets the content scroll position.
+
+> Regression pages such as `bad-case` and `text-align-right-bad-case` intentionally preserve historical invalid inputs. They verify compatibility and are not recommended production patterns. Use this guide and `TextCompositionArticle.tsx` for production code.
+
+## Correct structure
+
+```tsx
+<view className="card">
+  <text className="paragraph">
+    {"Continuous copy with identical styling stays in one string. "}
+    <text className="highlight">
+      {"Only distinct content needs nested text."}
+    </text>{" "}
+    <image className="icon" src={icon} />{" "}
+    <view className="badge">
+      <text className="badge-dot">{"●"}</text>
+      <text className="badge-label">{"Label"}</text>
+    </view>
+    {" End of paragraph."}
+  </text>
+</view>;
+```
+
+The outer view owns block layout such as the card, background, and padding. The outer text owns paragraph layout. Nested image and view nodes participate inline because they are children of that text.
+
+## Composition rules
+
+1. Use `<view>` for cards, backgrounds, padding, and other block layout.
+2. Use one outer `<text>` as the paragraph layout owner for natural wrapping, line height, truncation, and alignment.
+3. Nest `<text>` only when styling, events, semantics, or direction differ. Keep adjacent same-style copy in one string instead of splitting it at visual line boundaries.
+4. Nest `<image>` directly for an inline image. Nest `<view>` for an atomic inline structure with multiple children.
+5. Keep adjacent CJK fragments adjacent. Write `{" "}` when a real space is required instead of relying on JSX indentation.
+
+## Paragraph properties
+
+Set `line-height`, `text-align`, `text-indent`, `white-space`, `text-maxline`, and `text-overflow` on the outer text. `line-height` is a paragraph property; applying it to nested text does not change the paragraph line box.
+
+```tsx
+<text
+  className="paragraph"
+  text-maxline={expanded ? "-1" : "3"}
+>
+  {content}
+  {!expanded && (
+    <inline-truncation>
+      <text className="more" bindtap={expand}>{"…More"}</text>
+    </inline-truncation>
+  )}
+</text>;
+```
+
+```css
+.paragraph {
+  overflow: hidden;
+  font-size: 28rpx;
+  line-height: 44rpx;
+  text-align: left;
+  text-overflow: ellipsis;
+}
+```
+
+Do not insert manual newlines based on a particular design width or split source data by visual line. Container width, copy, font metrics, font scale, and platform differences invalidate those boundaries.
+
+## Inline display and vertical alignment
+
+In Lynx, `display` controls how an element lays out its children. It does not determine whether that element is block or inline in its parent. Web values such as `display: inline`, `inline-block`, `inline-flex`, and `inline-grid` are not a migration strategy.
+
+```tsx
+<text className="paragraph">
+  {"Body copy "}
+  <view className="badge">
+    <text className="dot">{"●"}</text>
+    <text className="label">{"Low"}</text>
+  </view>
+  {" continues here."}
+</text>;
+```
+
+```css
+.badge {
+  /* This display value only controls the badge children. */
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  /* Inline identity comes from nesting the view in the outer text. */
+  vertical-align: center;
+}
+```
+
+`vertical-align` applies to inline text, image, and view nodes. Its default is `baseline`, and it does not inherit. Set it explicitly on every inline node that needs a different alignment. Do not rely on `flex`, `flex-grow`, or `flex-shrink` on inline nodes to allocate text-line space.
+
+## Events and dynamic state
+
+Nested text, image, and view nodes may each own a tap handler. Do not split continuous copy into same-style nodes solely to attach events; wrap only the interactive semantic span.
+
+Preserve relationships between source states when migrating regression cases. For example, tapping `inline-truncation-update` inverts `control` and sets another paragraph's `line` to `-1`. This example keeps that exact transition instead of rewriting it as a generic expand/collapse interaction.
+
+## Internationalization and line breaking
+
+- Keep mixed Arabic, English, CJK, and emoji in one outer text when they belong to the same paragraph.
+- Set `direction: rtl | ltr` on the paragraph text when direction must be forced. Let ordinary dynamic content use direction inference.
+- Test `word-break: keep-all` and `hyphens: auto` with real language samples because they change available break points.
+- Prefer `text-align: start/end` for direction-aware dynamic copy instead of hard-coded left/right alignment.
+
+## Source case mapping
+
+| #  | Source case                    | Target component                | Preserved coverage                                                          |
+| -- | ------------------------------ | ------------------------------- | --------------------------------------------------------------------------- |
+| 01 | `bad-case`                     | `BadCase`                       | counter/slot, gradient updates, overflow, maxlength, decoration             |
+| 02 | `basic`                        | `BasicCase`                     | alignment, 100–800/bold, font style, decoration, single/multiple shadows    |
+| 03 | `bidi-text`                    | `BidiTextCase`                  | five auto/LTR/RTL inputs, inline view, single-line truncation               |
+| 04 | `boring-layout`                | `BoringLayoutCase`              | nowrap, max-content, line height, alignment, CJK, inline view, empty text   |
+| 05 | `event-with-padding`           | `EventWithPaddingCase`          | three counters and six padding/margin/border hit-region inputs              |
+| 06 | `font-family-weight`           | `FontFamilyWeightCase`          | 800/400, public font fallbacks, nested italic regression sentence           |
+| 07 | `hyphens-auto`                 | `HyphensAutoCase`               | auto/none with and without soft hyphens                                     |
+| 08 | `inline-element-align-center`  | `InlineElementAlignCenterCase`  | single-line text/image/view composition and centering                       |
+| 09 | `inline-text`                  | `InlineTextCase`                | concatenation, sizes, color/gradient inheritance and overrides              |
+| 10 | `inline-text-background-image` | `InlineTextBackgroundImageCase` | six maxline, alignment, line-height, background, and custom-tail inputs     |
+| 11 | `inline-truncation`            | `InlineTruncationCase`          | height/line-height, overflow, empty content, percentage tails, flex sibling |
+| 12 | `inline-truncation-event`      | `InlineTruncationEventCase`     | LTR/RTL by truncation/view/image/text across eight states                   |
+| 13 | `inline-truncation-rtl`        | `InlineTruncationRtlCase`       | 16 direction, maxline, tail, emoji, and vertical-align inputs               |
+| 14 | `inline-truncation-update`     | `InlineTruncationUpdateCase`    | inverted `control`, `line=-1`, five inline views, and custom tail           |
+| 15 | `layer-basic`                  | `LayerBasicCase`                | independent basic matrix and retired renderer boundary                      |
+| 16 | `layer-inline-text`            | `LayerInlineTextCase`           | independent inline-text matrix and retired renderer boundary                |
+| 17 | `layer-multi-line`             | `LayerMultiLineCase`            | unlimited, two-line, four-line, nowrap, and ellipsis                        |
+| 18 | `multi-line`                   | `MultiLineCase`                 | tap toggle between `1` and empty plus four static comparisons               |
+| 19 | `multiple-font-family`         | `MultipleFontFamilyCase`        | seven font orders and empty-family boundaries                               |
+| 20 | `text-align-right-bad-case`    | `TextAlignRightBadCase`         | fixed sibling width, outer border/margin, inner right alignment             |
+| 21 | `text-indent`                  | `TextIndentCase`                | percentage, small, none, large, max-content, and fixed-width inputs         |
+| 22 | `transform`                    | `TransformCase`                 | 5rad, transform origin, top/left, and 0.5 scale                             |
+| 23 | `white-space`                  | `WhiteSpaceCase`                | normal long copy and nowrap copy with a source newline                      |
+| 24 | `word-break-keep-all`          | `WordBreakKeepAllCase`          | keep-all/normal comparison using the same multilingual copy                 |
+
+### Public compatibility boundaries
+
+- The legacy MiniApp DSL becomes ReactLynx JSX. Legacy `inline-text` and `inline-image` become nested `<text>` and `<image>` elements.
+- System font fallbacks and a deterministic data URI replace private fonts, domains, and large source images while preserving order, sizing, and consumption behavior.
+- The current public page API does not expose `enableTextLayerRender`, `enableTextBoringLayout`, or the retired `text-vertical-align` property. Corresponding pages preserve the visible inputs and display an explicit compatibility note.
+- Host lifecycle logging is outside this public example. Component state and tap events remain represented.
+
+## Review checklist
+
+- [ ] Every visible string is inside `<text>`.
+- [ ] A continuous naturally wrapping passage has one outer `<text>`.
+- [ ] No copy is split or manually wrapped for one fixed design width.
+- [ ] Adjacent same-style copy is not divided into meaningless nodes.
+- [ ] Inline image/view identity comes from nesting inside `<text>`.
+- [ ] An inline view's `display` value only controls its own children.
+- [ ] `vertical-align` is set on each relevant inline text/image/view and is not assumed to inherit.
+- [ ] Paragraph `line-height`, `text-align`, `text-maxline`, and truncation live on the outer text.
+- [ ] Inline nodes do not depend on flex sizing or Web `display: inline-*` behavior.
+- [ ] Wrapping and vertical alignment are verified across widths, dynamic copy, font scaling, Android, iOS, and HarmonyOS.
+
+## Official references
+
+- [Lynx Typography](https://lynxjs.org/next/guide/styling/text-and-typography.html): visible text belongs in `<text>`; nest text/image/view for mixed content.
+- [Lynx `<text>` element](https://lynxjs.org/api/elements/built-in/text.html): `<text>` creates an inline-formatting-like layout context; nested `<view>` participates as an inline view.
+- [Lynx `display`](https://lynxjs.org/next/api/css/properties/display.html): Lynx does not support Web block/inline and inline-* display values; display controls child layout.
+- [Lynx `vertical-align`](https://lynxjs.org/next/api/css/properties/vertical-align.html): the property applies to inline text/image/view, defaults to `baseline`, and does not inherit.
+- [Lynx `line-height`](https://lynxjs.org/next/api/css/properties/line-height.html): line height is a paragraph property and has no effect on inline text.
+
+## Non-goals
+
+- Do not reproduce retired renderer backend switches.
+- Do not depend on business networks, host services, analytics, or private font resources.
+- Do not treat one platform screenshot as cross-platform acceptance. The Android LynxView captures verify this build and its key layout states; run the platform matrix on the corresponding clients.

--- a/examples/text-composition/SKILL.md
+++ b/examples/text-composition/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: text-composition
+description: Use when implementing or reviewing ReactLynx content that needs continuous text measurement, natural wrapping, nested text/image/view composition, truncation, vertical alignment, bidirectional text, or language-aware line breaking.
+---
+
+# Lynx Text Composition
+
+Build a continuous text composition around one outer `<text>`. Treat that element as the owner of paragraph measurement and line layout.
+
+## Workflow
+
+1. Separate block layout from continuous text layout.
+2. Use an outer `<view>` for the card, background, padding, and other block concerns.
+3. Put the complete naturally wrapping paragraph in one outer `<text>`.
+4. Nest `<text>` only when a span has different styling, semantics, or events.
+5. Nest `<image>` directly for an inline image. Nest `<view>` for an atomic inline structure with multiple children.
+6. Put paragraph properties such as `line-height`, `text-align`, `text-indent`, `text-maxline`, and truncation on the outer `<text>`.
+7. Keep adjacent Chinese fragments adjacent. Write `{" "}` when a real space is required.
+8. Verify narrow and wide containers, dynamic copy, font scaling, and every target platform.
+
+## Canonical structure
+
+```tsx
+<view className="card">
+  <text className="paragraph">
+    {"Continuous body copy stays in one string. "}
+    <text className="emphasis">{"Only distinct spans are nested."}</text>{" "}
+    <image className="icon" src={icon} />{" "}
+    <view className="badge">
+      <text className="badgeDot">{"●"}</text>
+      <text className="badgeLabel">{"Label"}</text>
+    </view>
+  </text>
+</view>;
+```
+
+```css
+.paragraph {
+  overflow: hidden;
+  font-size: 28rpx;
+  line-height: 44rpx;
+  text-align: left;
+  text-overflow: ellipsis;
+}
+
+.icon,
+.badge {
+  vertical-align: center;
+}
+
+.badge {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+```
+
+The nested position gives image/view nodes their inline identity. `display` on the badge controls only how the badge lays out its children.
+
+## Guardrails
+
+- Put every visible string inside `<text>`.
+- Do not split a paragraph into flex rows or strings based on a design width.
+- Do not use Web-only `display: inline`, `inline-block`, `inline-flex`, or `inline-grid` values.
+- Do not rely on `flex`, `flex-grow`, or `flex-shrink` on inline nodes to allocate text-line space.
+- Set `vertical-align` on each nested text/image/view that needs it; the property does not inherit.
+- Do not set paragraph `line-height` on an inline child and expect it to change the paragraph line box.
+- Preserve source state transitions and event boundaries when migrating regression cases.
+- Replace private resources and retired host switches with public deterministic equivalents, and document the compatibility boundary instead of inventing an API.
+
+## Review and validation
+
+1. Read [README.md](README.md) for the complete guide, official documentation links, and the 24-case source mapping.
+2. Use [src/components/TextCompositionArticle.tsx](src/components/TextCompositionArticle.tsx) as the production-oriented composition example.
+3. Use [src/cases/registry.tsx](src/cases/registry.tsx) and the case implementations for focused regression inputs; historical bad cases are test fixtures, not recommended patterns.
+4. Run:
+
+   ```bash
+   pnpm --filter @lynx-example/text-composition run build
+   pnpm dprint check
+   pnpm meta-updater --test
+   ```
+
+5. Capture each relevant case on a Lynx runtime. Confirm wrapping, truncation, events, direction, and vertical alignment rather than checking only that the page loads.

--- a/examples/text-composition/lynx.config.ts
+++ b/examples/text-composition/lynx.config.ts
@@ -1,0 +1,24 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { pluginQRCode } from "@lynx-js/qrcode-rsbuild-plugin";
+import { pluginReactLynx } from "@lynx-js/react-rsbuild-plugin";
+import { defineConfig } from "@lynx-js/rspeedy";
+import { pluginTypeCheck } from "@rsbuild/plugin-type-check";
+
+export default defineConfig({
+  plugins: [
+    pluginQRCode(),
+    pluginReactLynx(),
+    pluginTypeCheck(),
+  ],
+  environments: {
+    web: {},
+    lynx: {},
+  },
+  output: {
+    assetPrefix: "https://lynxjs.org/lynx-examples/text-composition/dist",
+    filename: "[name].[platform].bundle",
+  },
+});

--- a/examples/text-composition/package.json
+++ b/examples/text-composition/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@lynx-example/text-composition",
+  "version": "0.1.0",
+  "description": "A Lynx text-composition example covering natural wrapping, inline text, images, views, and truncation",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lynx-family/lynx-examples.git",
+    "directory": "examples/text-composition"
+  },
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
+  "type": "module",
+  "files": [
+    "dist/",
+    "src/",
+    "lynx.config.ts",
+    "README.md",
+    "CHANGELOG.md",
+    "SKILL.md"
+  ],
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev",
+    "preview": "rspeedy preview"
+  },
+  "dependencies": {
+    "@lynx-js/react": "catalog:"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "catalog:",
+    "@lynx-js/react-rsbuild-plugin": "catalog:",
+    "@lynx-js/rspeedy": "catalog:",
+    "@lynx-js/types": "catalog:",
+    "@types/react": "^18.3.28",
+    "typescript": "~5.9.3"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/examples/text-composition/src/App.css
+++ b/examples/text-composition/src/App.css
@@ -1,0 +1,1295 @@
+/* Copyright 2026 The Lynx Authors. All rights reserved.
+ * Licensed under the Apache License Version 2.0 that can be found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+* {
+  box-sizing: border-box;
+}
+
+.case-page {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100vh;
+  background-color: #f4f0e8;
+}
+
+.case-navigator {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding: 30rpx 34rpx 26rpx;
+  background-color: #153f37;
+}
+
+.case-navigator-copy {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  padding-right: 24rpx;
+}
+
+.case-progress,
+.case-stage-kicker {
+  color: #f4c66f;
+  font-size: 22rpx;
+  font-weight: 700;
+  letter-spacing: 2rpx;
+}
+
+.case-source-name {
+  margin-top: 8rpx;
+  color: #ffffff;
+  font-size: 42rpx;
+  font-weight: 800;
+  line-height: 50rpx;
+}
+
+.case-source-title {
+  margin-top: 6rpx;
+  color: #d7eee7;
+  font-size: 26rpx;
+  font-weight: 600;
+  line-height: 34rpx;
+}
+
+.case-source-note {
+  margin-top: 8rpx;
+  color: #a9c9c0;
+  font-size: 21rpx;
+  line-height: 29rpx;
+}
+
+.case-navigation-controls {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.case-navigation-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 112rpx;
+  height: 66rpx;
+  margin-left: 12rpx;
+  padding: 0 20rpx;
+  border: 2rpx solid #6e9a8e;
+  border-radius: 18rpx;
+}
+
+.case-navigation-button--primary {
+  border-color: #f4c66f;
+  background-color: #f4c66f;
+}
+
+.case-navigation-button-text {
+  color: #d7eee7;
+  font-size: 22rpx;
+  font-weight: 700;
+}
+
+.case-navigation-button-text--primary {
+  color: #153f37;
+}
+
+.case-scroll {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+}
+
+.case-stage {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  padding: 28rpx 30rpx 54rpx;
+}
+
+.case-stage-heading {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 22rpx;
+  padding-bottom: 18rpx;
+  border-bottom: 2rpx solid #d8d0c3;
+}
+
+.case-stage-kicker {
+  color: #a85b2d;
+}
+
+.case-stage-id {
+  color: #6b716c;
+  font-size: 21rpx;
+  font-weight: 600;
+}
+
+.case-stage-footer {
+  margin-top: 28rpx;
+  padding: 22rpx;
+  border-radius: 18rpx;
+  background-color: #e7e0d4;
+}
+
+.case-stage-footer-text {
+  color: #6b716c;
+  font-size: 21rpx;
+  line-height: 30rpx;
+}
+
+.fixture-column,
+.fixture-group,
+.fixture-group-content {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.fixture-group {
+  margin-bottom: 18rpx;
+  padding: 18rpx;
+  border: 2rpx solid #ded6ca;
+  border-radius: 18rpx;
+  background-color: #fffdfa;
+}
+
+.fixture-label {
+  margin-bottom: 12rpx;
+  color: #9a512a;
+  font-size: 21rpx;
+  font-weight: 700;
+  line-height: 28rpx;
+}
+
+.compatibility-note {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 18rpx;
+  padding: 18rpx 20rpx;
+  border-left: 6rpx solid #d3a24f;
+  border-radius: 12rpx;
+  background-color: #fff3d8;
+}
+
+.compatibility-note-title {
+  color: #8e5a12;
+  font-size: 18rpx;
+  font-weight: 800;
+  letter-spacing: 1rpx;
+}
+
+.compatibility-note-copy {
+  margin-top: 7rpx;
+  color: #6f5428;
+  font-size: 21rpx;
+  line-height: 30rpx;
+}
+
+.value-badge {
+  padding: 5rpx 10rpx;
+  border-radius: 10rpx;
+  color: #ffffff;
+  background-color: #315e54;
+  font-size: 19rpx;
+  vertical-align: center;
+}
+
+/* bad-case */
+.bad-offer-card {
+  display: flex;
+  flex-direction: column;
+  width: 224rpx;
+  height: 192rpx;
+  overflow: visible;
+  border-radius: 16rpx;
+  background-color: #fff1e5;
+  box-shadow: 0 4rpx 16rpx rgba(173, 85, 47, 0.2);
+}
+
+.bad-offer-copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 120rpx;
+}
+
+.bad-offer-copy-text {
+  color: #a6432c;
+  font-size: 22rpx;
+  line-height: 30rpx;
+  text-align: center;
+}
+
+.bad-offer-highlight {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  height: 52rpx;
+}
+
+.bad-offer-normal {
+  color: #881e06;
+  font-size: 28rpx;
+  font-weight: 500;
+  line-height: 40rpx;
+}
+
+.bad-offer-amount {
+  margin: 0 4rpx;
+  color: #d84059;
+  font-family: Georgia, serif;
+  font-size: 36rpx;
+  font-weight: 700;
+  line-height: 42rpx;
+}
+
+.source-counter {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.source-counter-text {
+  color: #2863a5;
+  font-size: 40rpx;
+  line-height: 54rpx;
+}
+
+.source-counter-slot {
+  color: #c84236;
+  font-size: 22rpx;
+  vertical-align: baseline;
+}
+
+.gradient-regression-row {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 12rpx;
+  padding: 14rpx;
+  border-radius: 12rpx;
+  background-color: #f5f1ea;
+}
+
+.regression-caption {
+  color: #777168;
+  font-size: 19rpx;
+}
+
+.gradient-source-text {
+  margin-top: 4rpx;
+  overflow: visible;
+  color: linear-gradient(90deg, #5c9fcc 15.94%, #1e4bff 84.78%);
+  font-size: 30rpx;
+  font-weight: 700;
+  line-height: 40rpx;
+}
+
+.gradient-source-text--hidden {
+  overflow: hidden;
+}
+
+.gradient-source-text--changed {
+  color: #d23838;
+}
+
+.bad-maxlength {
+  padding: 12rpx;
+  color: #31413d;
+  background-color: #f4efe5;
+  font-size: 28rpx;
+  text-overflow: ellipsis;
+}
+
+.bad-decoration-surface {
+  margin-top: 12rpx;
+  padding: 12rpx;
+  background-color: #b94336;
+}
+
+.bad-decoration-text {
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 40rpx;
+  text-decoration: line-through;
+}
+
+/* basic and layer-basic */
+.basic-expectation {
+  width: 100%;
+  color: #303b38;
+  font-size: 28rpx;
+  line-height: 38rpx;
+}
+
+.basic-align-left {
+  text-align: left;
+}
+
+.basic-align-right {
+  text-align: right;
+}
+
+.basic-align-center {
+  text-align: center;
+}
+
+.weight-matrix {
+  display: flex;
+  flex-direction: column;
+}
+
+.source-weight-100 {
+  font-weight: 100;
+}
+
+.source-weight-200 {
+  font-weight: 200;
+}
+
+.source-weight-300 {
+  font-weight: 300;
+}
+
+.source-weight-400 {
+  font-weight: 400;
+}
+
+.source-weight-500 {
+  font-weight: 500;
+}
+
+.source-weight-600 {
+  font-weight: 600;
+}
+
+.source-weight-700 {
+  font-weight: 700;
+}
+
+.source-weight-bold,
+.source-weight-800 {
+  font-weight: 800;
+}
+
+.basic-italic {
+  font-style: italic;
+}
+
+.basic-italic-bold {
+  font-style: italic;
+  font-weight: 700;
+}
+
+.basic-underline {
+  text-decoration: underline;
+}
+
+.basic-line-through {
+  text-decoration: line-through;
+}
+
+.basic-shadow-single {
+  text-shadow: 2rpx 2rpx 4rpx #558abb;
+}
+
+.basic-shadow-multiple {
+  text-shadow: 2rpx 2rpx 4rpx #d33c35, 0 0 18rpx #3e5ac9, 0 0 4rpx #3e5ac9;
+}
+
+/* bidi-text */
+.bidi-source-container {
+  width: 400rpx;
+}
+
+.bidi-source-row {
+  width: 100%;
+  margin-bottom: 14rpx;
+  padding: 10rpx;
+  overflow: hidden;
+  border: 2rpx solid #d9d0c4;
+  color: #273b36;
+  font-size: 28rpx;
+  line-height: 38rpx;
+  text-overflow: ellipsis;
+}
+
+.bidi-source-box {
+  width: 40rpx;
+  height: 20rpx;
+  background-color: #d8453b;
+  vertical-align: baseline;
+}
+
+.bidi-source-ltr {
+  direction: ltr;
+}
+
+.bidi-source-rtl {
+  direction: rtl;
+}
+
+/* boring-layout */
+.boring-source-container {
+  width: max-content;
+  padding: 20rpx;
+  background-color: #f7dce2;
+}
+
+.boring-row {
+  margin-bottom: 10rpx;
+  border: 2rpx solid #d33b36;
+  color: #303b38;
+  font-size: 26rpx;
+}
+
+.boring-nowrap {
+  white-space: nowrap;
+}
+
+.boring-max-content {
+  width: max-content;
+}
+
+.boring-line-height-large {
+  line-height: 60rpx;
+}
+
+.boring-line-height-small {
+  line-height: 20rpx;
+}
+
+.boring-centered,
+.boring-right {
+  width: 200rpx;
+}
+
+.boring-centered {
+  text-align: center;
+}
+
+.boring-right {
+  text-align: right;
+}
+
+.boring-inline-view {
+  width: 20rpx;
+  height: 20rpx;
+  background-color: #315cd3;
+  vertical-align: baseline;
+}
+
+.boring-empty {
+  min-height: 24rpx;
+}
+
+/* event-with-padding */
+.event-counts {
+  margin-bottom: 18rpx;
+  font-size: 22rpx;
+  line-height: 34rpx;
+}
+
+.event-source-block {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 14rpx;
+}
+
+.event-source-label {
+  margin-bottom: 5rpx;
+  color: #8c5a34;
+  font-size: 19rpx;
+  font-weight: 700;
+}
+
+.event-source-line {
+  min-height: 60rpx;
+  border-radius: 10rpx;
+  color: #273b36;
+  background-color: #fffdfa;
+  font-size: 24rpx;
+  line-height: 60rpx;
+}
+
+.event-source-view,
+.event-source-image {
+  width: 40rpx;
+  height: 40rpx;
+  margin-right: 8rpx;
+  vertical-align: center;
+}
+
+.event-source-view {
+  background-color: #d54239;
+}
+
+.event-source-image {
+  border-radius: 20rpx;
+  background-color: #275e53;
+}
+
+.event-source-text {
+  color: #2e5cb8;
+  vertical-align: center;
+}
+
+.event-padding-left {
+  padding-left: 200rpx;
+}
+
+.event-margin-left {
+  margin-left: 200rpx;
+}
+
+.event-border-left {
+  border-left: 200rpx solid #ead9cf;
+}
+
+.event-padding-top {
+  padding-top: 60rpx;
+}
+
+.event-margin-top {
+  margin-top: 60rpx;
+}
+
+.event-border-top {
+  border-top: 60rpx solid #ead9cf;
+}
+
+/* font-family-weight */
+.font-source-800,
+.font-source-400,
+.font-source-display,
+.font-source-question {
+  color: #283a36;
+  font-size: 36rpx;
+  line-height: 48rpx;
+}
+
+.font-source-800 {
+  font-family: Georgia, serif;
+  font-weight: 800;
+}
+
+.font-source-400 {
+  font-family: Georgia, serif;
+  font-weight: 400;
+}
+
+.font-source-display {
+  padding: 12rpx;
+  color: #ffffff;
+  background-color: #c55d71;
+  font-family: Arial, sans-serif;
+  font-size: 40rpx;
+  font-weight: 600;
+  line-height: 48rpx;
+}
+
+.font-source-question {
+  margin-top: 20rpx;
+  font-family: Arial, sans-serif;
+  font-size: 40rpx;
+}
+
+.font-source-question-part {
+  vertical-align: baseline;
+}
+
+.font-source-question-italic {
+  font-style: italic;
+}
+
+/* hyphens-auto */
+.hyphen-source-container {
+  width: 300rpx;
+  padding: 14rpx;
+  border: 2rpx solid #d63c34;
+}
+
+.hyphen-source-row {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 18rpx;
+}
+
+.hyphen-source-label {
+  color: #8d512e;
+  font-size: 19rpx;
+  font-weight: 700;
+}
+
+.hyphen-source-text {
+  color: #2a3a37;
+  font-size: 50rpx;
+  line-height: 60rpx;
+}
+
+.hyphens-on {
+  hyphens: auto;
+}
+
+.hyphens-off {
+  hyphens: none;
+}
+
+/* inline-element-align-center */
+.inline-center-source-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20rpx;
+  border: 2rpx solid #d64239;
+}
+
+.inline-center-source-text {
+  width: 100%;
+  overflow: hidden;
+  color: #253d37;
+  font-size: 50rpx;
+  line-height: 60rpx;
+  text-align: center;
+  text-overflow: ellipsis;
+}
+
+.inline-center-source-image {
+  width: 60rpx;
+  height: 40rpx;
+  border-radius: 20rpx;
+  background-color: #2d6257;
+  vertical-align: center;
+}
+
+.inline-center-source-view {
+  width: 100rpx;
+  height: 40rpx;
+  background-color: #e5bd50;
+  vertical-align: center;
+}
+
+/* inline-text and layer-inline-text */
+.inline-source-paragraph {
+  width: 100%;
+  margin-bottom: 8rpx;
+  color: #303b38;
+  font-size: 32rpx;
+  line-height: 44rpx;
+}
+
+.inline-source-small {
+  font-size: 20rpx;
+}
+
+.inline-source-large {
+  font-size: 60rpx;
+}
+
+.inline-source-blue {
+  color: #2e54d3;
+}
+
+.inline-source-cyan {
+  color: #2bc5d6;
+}
+
+.inline-source-gradient-right {
+  color: linear-gradient(to right, #d33b38, #65499c, #62efff);
+}
+
+.inline-source-gradient-left {
+  color: linear-gradient(to left, #e4b93f, #171717);
+}
+
+.inline-source-outer-gradient {
+  color: linear-gradient(to right, #d33b38, #65499c, #62efff);
+}
+
+.inline-source-overflow-hidden {
+  overflow: hidden;
+}
+
+.inline-source-overflow-visible {
+  overflow: visible;
+}
+
+.inline-source-italic {
+  font-style: italic;
+}
+
+.inline-source-line-through {
+  text-decoration: line-through;
+}
+
+/* inline-text-background-image */
+.background-source-paragraph {
+  width: 100%;
+  margin-bottom: 6rpx;
+  overflow: hidden;
+  color: #303b38;
+  font-size: 36rpx;
+  line-height: 46rpx;
+  text-overflow: ellipsis;
+}
+
+.background-source-paragraph--line-height {
+  line-height: 60rpx;
+}
+
+.background-source-paragraph--compact {
+  line-height: 50rpx;
+}
+
+.background-source-center {
+  text-align: center;
+}
+
+.background-source-right {
+  text-align: right;
+}
+
+.background-source-ellipsis {
+  text-overflow: ellipsis;
+}
+
+.background-source-gradient,
+.background-source-rounded,
+.background-source-dotted {
+  background-position: 0 100%;
+  background-repeat: no-repeat;
+  vertical-align: baseline;
+}
+
+.background-source-gradient {
+  background-image: linear-gradient(
+    360deg,
+    rgba(74, 170, 159, 0.3) 0%,
+    rgba(74, 170, 159, 0) 100%
+  );
+  background-size: 100% 16rpx;
+}
+
+.background-source-rounded {
+  border-radius: 20rpx;
+  background-image: linear-gradient(
+    360deg,
+    rgba(170, 128, 74, 0.3) 0%,
+    rgba(170, 96, 74, 0) 100%
+  );
+  background-size: 100% 16rpx;
+}
+
+.background-source-dotted {
+  background-image: linear-gradient(
+    to right,
+    #50525a,
+    #50525a 50%,
+    transparent 50%,
+    transparent
+  );
+  background-size: 10rpx 2rpx;
+  background-repeat: repeat no-repeat;
+}
+
+.background-source-inline-view {
+  display: flex;
+  flex-direction: row;
+  vertical-align: baseline;
+}
+
+.background-source-inline-view-text {
+  color: #2d4a43;
+}
+
+.background-source-full {
+  color: #d33a35;
+}
+
+/* inline-truncation */
+.trunc-basic-row,
+.rtl-source-row,
+.hyphen-source-row,
+.font-source-row {
+  display: flex;
+  flex-direction: column;
+}
+
+.trunc-basic-row,
+.rtl-source-row {
+  margin-bottom: 12rpx;
+}
+
+.trunc-basic-label,
+.rtl-source-label,
+.font-source-label {
+  margin-bottom: 4rpx;
+  color: #8b5a35;
+  font-size: 18rpx;
+  font-weight: 700;
+}
+
+.trunc-basic-text {
+  width: 100%;
+  overflow: hidden;
+  border: 2rpx solid #d83d37;
+  color: #273a36;
+  font-size: 23rpx;
+  line-height: 40rpx;
+}
+
+.trunc-height-10 {
+  height: 20rpx;
+}
+
+.trunc-height-20 {
+  height: 40rpx;
+}
+
+.trunc-height-25 {
+  height: 50rpx;
+}
+
+.trunc-height-30 {
+  height: 60rpx;
+}
+
+.trunc-height-40 {
+  height: 80rpx;
+}
+
+.trunc-height-50 {
+  height: 100rpx;
+}
+
+.trunc-overflow-visible {
+  overflow: visible;
+}
+
+.trunc-ellipsis {
+  text-overflow: ellipsis;
+}
+
+.trunc-no-line-height {
+  line-height: normal;
+}
+
+.trunc-basic-tail-view {
+  width: 60rpx;
+  height: 20rpx;
+  background-color: #d33d35;
+  vertical-align: baseline;
+}
+
+.trunc-basic-tail-view--percentage {
+  width: 50%;
+}
+
+.trunc-basic-tail-text {
+  color: #8b3a2e;
+  vertical-align: baseline;
+}
+
+.trunc-maxline-two {
+  height: auto;
+  text-overflow: ellipsis;
+}
+
+.trunc-basic-flex-row {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.trunc-basic-flex-row > text {
+  width: 32%;
+}
+
+/* inline-truncation-event */
+.trunc-event-text {
+  width: 100%;
+  margin: 6rpx 0;
+  overflow: hidden;
+  color: #202927;
+  font-size: 23rpx;
+  line-height: 38rpx;
+  text-overflow: ellipsis;
+}
+
+.trunc-event-text--active {
+  color: #d23a35;
+}
+
+.trunc-event-text--rtl {
+  direction: rtl;
+}
+
+.trunc-event-nested {
+  color: #777777;
+  font-size: 26rpx;
+  vertical-align: baseline;
+}
+
+.trunc-event-view {
+  width: 60rpx;
+  height: 20rpx;
+  background-color: #d33e36;
+  vertical-align: baseline;
+}
+
+.trunc-event-view--large {
+  height: 40rpx;
+}
+
+.trunc-event-image,
+.trunc-event-tail-image,
+.trunc-event-image-small {
+  border-radius: 8rpx;
+  background-color: #2b6559;
+  vertical-align: baseline;
+}
+
+.trunc-event-image,
+.trunc-event-tail-image {
+  width: 40rpx;
+  height: 60rpx;
+}
+
+.trunc-event-image-small {
+  width: 30rpx;
+  height: 30rpx;
+}
+
+/* inline-truncation-rtl */
+.rtl-source-text {
+  width: 100%;
+  overflow: hidden;
+  border: 2rpx solid #d33c35;
+  color: #243b35;
+  font-size: 23rpx;
+  line-height: 36rpx;
+}
+
+.rtl-source-direction {
+  direction: rtl;
+}
+
+.rtl-source-ltr {
+  direction: ltr;
+}
+
+.rtl-source-ellipsis {
+  text-overflow: ellipsis;
+}
+
+.rtl-source-tail-view,
+.rtl-source-tail-image {
+  vertical-align: baseline;
+}
+
+.rtl-source-tail-view {
+  width: 40rpx;
+  height: 20rpx;
+  background-color: #d43e36;
+}
+
+.rtl-source-tail-image {
+  width: 30rpx;
+  height: 30rpx;
+  border-radius: 7rpx;
+  background-color: #2e655a;
+}
+
+.rtl-source-tail-view--raised {
+  vertical-align: 20rpx;
+}
+
+.rtl-source-tail-image--lowered {
+  vertical-align: -20rpx;
+}
+
+/* inline-truncation-update */
+.trunc-update-root {
+  padding: 18rpx;
+  border: 2rpx dashed #c78c54;
+  border-radius: 16rpx;
+  background-color: #fffaf1;
+}
+
+.trunc-update-status {
+  margin-bottom: 14rpx;
+  font-size: 21rpx;
+}
+
+.trunc-update-primary {
+  overflow: hidden;
+  color: #d23b35;
+  font-size: 40rpx;
+  line-height: 54rpx;
+  text-overflow: ellipsis;
+}
+
+.trunc-update-tail-text {
+  color: #777777;
+  font-size: 48rpx;
+  vertical-align: baseline;
+}
+
+.trunc-update-secondary {
+  width: 380rpx;
+  margin-top: 20rpx;
+  overflow: hidden;
+  color: #253b36;
+  font-size: 24rpx;
+  line-height: 44rpx;
+  text-overflow: ellipsis;
+}
+
+.trunc-update-item {
+  margin: 20rpx;
+  background-color: #d63d36;
+  vertical-align: baseline;
+}
+
+.trunc-update-item-text {
+  max-width: 60rpx;
+  margin-left: 20rpx;
+  overflow: hidden;
+  color: #ffffff;
+  text-overflow: ellipsis;
+}
+
+.trunc-update-green-tail {
+  width: 20rpx;
+  height: 20rpx;
+  margin: 20rpx;
+  background-color: #2a8a55;
+}
+
+.trunc-update-hint {
+  margin-top: 18rpx;
+  color: #755b3c;
+  font-size: 20rpx;
+}
+
+/* layer-multi-line and multi-line */
+.multiline-source-text {
+  width: 100%;
+  overflow: hidden;
+  color: #2c3b37;
+  font-size: 28rpx;
+  line-height: 40rpx;
+}
+
+.multiline-ellipsis {
+  text-overflow: ellipsis;
+}
+
+.multiline-nowrap-window {
+  width: 100%;
+  overflow: hidden;
+}
+
+.multiline-nowrap {
+  white-space: nowrap;
+}
+
+.multiline-state {
+  margin-bottom: 10rpx;
+  font-size: 21rpx;
+}
+
+/* multiple-font-family */
+.font-source-row {
+  margin-bottom: 14rpx;
+  padding: 14rpx;
+  border-radius: 14rpx;
+  background-color: #fffdfa;
+}
+
+.font-source-sample {
+  color: #263b35;
+  font-size: 64rpx;
+  line-height: 76rpx;
+}
+
+.font-source-f1 {
+  font-family: Georgia, sans-serif;
+}
+
+.font-source-f2 {
+  font-family: MissingPublicFont, Georgia;
+}
+
+.font-source-f3 {
+  font-family: "";
+}
+
+.font-source-f4 {
+  font-family: "", Georgia;
+}
+
+.font-source-f5 {
+  font-family: Georgia, "";
+}
+
+.font-source-f6 {
+  font-family: monospace;
+}
+
+.font-source-f7 {
+  font-family: monospace, Georgia;
+}
+
+/* text-align-right-bad-case */
+.align-right-source-root {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.align-right-source-spacer {
+  flex-shrink: 0;
+  width: 234rpx;
+  height: 40rpx;
+  background-color: #d33d35;
+}
+
+.align-right-source-content {
+  display: flex;
+  flex: 1;
+}
+
+.align-right-source-outer {
+  margin-left: 40rpx;
+  border: 2rpx solid #d33d35;
+  color: #273a36;
+  font-size: 30rpx;
+  line-height: 42rpx;
+}
+
+.align-right-source-inner {
+  text-align: right;
+  vertical-align: baseline;
+}
+
+/* text-indent */
+.text-indent-source-root {
+  align-items: center;
+}
+
+.text-indent-source {
+  width: 400rpx;
+  margin: 20rpx 0;
+  border: 2rpx solid #d33c35;
+  color: #283b36;
+  font-size: 30rpx;
+  line-height: 42rpx;
+}
+
+.text-indent-source--percent {
+  text-indent: 10%;
+}
+
+.text-indent-source--small {
+  text-indent: 20rpx;
+}
+
+.text-indent-source--large {
+  text-indent: 100rpx;
+}
+
+.text-indent-source--max {
+  width: max-content;
+}
+
+/* transform */
+.transform-source-root {
+  display: flex;
+  flex-direction: column;
+  height: 440rpx;
+  border: 2rpx solid #d33b35;
+}
+
+.transform-source-outer {
+  width: 600rpx;
+  height: 200rpx;
+}
+
+.transform-source-text {
+  position: relative;
+  top: 160rpx;
+  left: 160rpx;
+  color: #ffffff;
+  background-color: #25824e;
+  font-size: 60rpx;
+}
+
+.transform-source-rotate {
+  transform: rotate(5rad);
+  transform-origin: 0 0;
+}
+
+.transform-source-scale {
+  transform: scale(0.5, 0.5);
+}
+
+/* white-space */
+.white-space-source-title {
+  width: 100%;
+  height: 40rpx;
+  margin-top: 30rpx;
+  color: #2d8cf0;
+  font-size: 25rpx;
+}
+
+.white-space-source-item {
+  width: 100%;
+  height: 200rpx;
+  overflow: hidden;
+  border: 2rpx solid #d43d35;
+  color: #293b37;
+  font-size: 27rpx;
+  line-height: 38rpx;
+}
+
+.white-space-source-normal {
+  white-space: normal;
+}
+
+.white-space-source-nowrap {
+  white-space: nowrap;
+}
+
+/* word-break-keep-all */
+.word-break-source-root {
+  width: 600rpx;
+  padding: 16rpx;
+  border: 2rpx solid #d33c35;
+}
+
+.word-break-source-label {
+  margin-top: 14rpx;
+  color: #89552f;
+  font-size: 22rpx;
+  font-weight: 700;
+}
+
+.word-break-source-text {
+  color: #293b37;
+  font-size: 72rpx;
+  line-height: 82rpx;
+}
+
+.word-break-source-on {
+  word-break: keep-all;
+}
+
+.word-break-source-off {
+  word-break: normal;
+}

--- a/examples/text-composition/src/App.tsx
+++ b/examples/text-composition/src/App.tsx
@@ -1,0 +1,11 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import "./App.css";
+
+import { CaseGallery } from "./components/CaseGallery.jsx";
+
+export function App() {
+  return <CaseGallery />;
+}

--- a/examples/text-composition/src/cases/FoundationCases.tsx
+++ b/examples/text-composition/src/cases/FoundationCases.tsx
@@ -1,0 +1,272 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { type PropsWithChildren, useState } from "@lynx-js/react";
+
+import { inlineImage } from "../mockData.js";
+import { CompatibilityNote, FixtureGroup, ValueBadge } from "./shared.jsx";
+
+function Counter({ children }: PropsWithChildren) {
+  return (
+    <view className="source-counter">
+      <text className="source-counter-text">
+        {"Hello world "}
+        {children}
+      </text>
+    </view>
+  );
+}
+
+export function BadCase() {
+  const [changedColor, setChangedColor] = useState(false);
+
+  return (
+    <view className="fixture-column">
+      <FixtureGroup label="issue 6179 · stacked copy and amount">
+        <view className="bad-offer-card">
+          <view className="bad-offer-copy">
+            <text className="bad-offer-copy-text">{"邀请更多新朋友"}</text>
+            <text className="bad-offer-copy-text">{"下载并打开示例应用"}</text>
+            <text className="bad-offer-copy-text">{"完成公开演示任务"}</text>
+          </view>
+          <view className="bad-offer-highlight">
+            <text className="bad-offer-normal">{"可得"}</text>
+            <text className="bad-offer-amount">{"20"}</text>
+            <text className="bad-offer-normal">{"积分"}</text>
+          </view>
+        </view>
+      </FixtureGroup>
+
+      <FixtureGroup label="issue 6199 · nested component slot">
+        <Counter>
+          <text className="source-counter-slot">{"sub text"}</text>
+        </Counter>
+      </FixtureGroup>
+
+      <FixtureGroup label="issue 6228 · shared gradient update">
+        <view className="gradient-regression-row" bindtap={() => setChangedColor(true)}>
+          <text className="regression-caption">{"overflow: visible"}</text>
+          <text
+            className={changedColor ? "gradient-source-text gradient-source-text--changed" : "gradient-source-text"}
+          >
+            {"心心相映 · VISIBLE"}
+          </text>
+        </view>
+        <view className="gradient-regression-row" bindtap={() => setChangedColor(true)}>
+          <text className="regression-caption">{"overflow: hidden"}</text>
+          <text
+            className={changedColor
+              ? "gradient-source-text gradient-source-text--hidden gradient-source-text--changed"
+              : "gradient-source-text gradient-source-text--hidden"}
+          >
+            {"心心相映 · HIDDEN"}
+          </text>
+        </view>
+      </FixtureGroup>
+
+      <FixtureGroup label="maxlength and decoration regressions">
+        <text className="bad-maxlength" text-maxlength="10">
+          {"text-maxlength: 10, 文本显示测试"}
+        </text>
+        <view className="bad-decoration-surface">
+          <text className="bad-decoration-text">{"hello world"}</text>
+        </view>
+      </FixtureGroup>
+    </view>
+  );
+}
+
+const weights = ["100", "200", "300", "400", "500", "600", "700", "bold", "800"];
+
+export function BasicCase() {
+  return (
+    <view className="fixture-column">
+      <FixtureGroup label="simple text">
+        <text className="basic-expectation">{"简单文本场景"}</text>
+      </FixtureGroup>
+      <FixtureGroup label="text-align">
+        <text className="basic-expectation basic-align-left">{"text-align: left"}</text>
+        <text className="basic-expectation basic-align-right">{"text-align: right"}</text>
+        <text className="basic-expectation basic-align-center">{"text-align: center"}</text>
+      </FixtureGroup>
+      <FixtureGroup label="font-weight 100–800 and bold">
+        <view className="weight-matrix">
+          {weights.map((weight) => (
+            <text className={`basic-expectation source-weight-${weight}`} key={weight}>
+              {`font-weight: ${weight} 中文`}
+            </text>
+          ))}
+        </view>
+      </FixtureGroup>
+      <FixtureGroup label="font-style">
+        <text className="basic-expectation">{"font-style: normal (default)"}</text>
+        <text className="basic-expectation basic-italic">{"font-style: italic（斜体）"}</text>
+        <text className="basic-expectation basic-italic-bold">{"italic（斜体）+ bold（粗体）"}</text>
+      </FixtureGroup>
+      <FixtureGroup label="text-decoration">
+        <text className="basic-expectation basic-underline">{"text-decoration: underline"}</text>
+        <text className="basic-expectation basic-line-through">{"text-decoration: line-through"}</text>
+      </FixtureGroup>
+      <FixtureGroup label="text-shadow">
+        <text className="basic-expectation basic-shadow-single">{"single text shadow"}</text>
+        <text className="basic-expectation basic-shadow-multiple">{"multiple text shadows"}</text>
+      </FixtureGroup>
+    </view>
+  );
+}
+
+function BidiRow(
+  { className = "", leading, trailing }: { className?: string; leading: string; trailing: string },
+) {
+  return (
+    <text className={`bidi-source-row ${className}`} text-maxline="1">
+      {leading}
+      <view className="bidi-source-box" />
+      {trailing}
+    </text>
+  );
+}
+
+export function BidiTextCase() {
+  return (
+    <view className="fixture-column bidi-source-container">
+      <BidiRow leading="اَلْعَرَبِيَّةُ hello word " trailing=" hello word" />
+      <BidiRow leading="هذا نص اختباري " trailing=" هذا نص اختباري" />
+      <BidiRow leading="اَلْعَرَبِيَّةُ " trailing=" hello word" />
+      <BidiRow className="bidi-source-ltr" leading="اَلْعَرَبِيَّةُ " trailing=" hello word" />
+      <BidiRow className="bidi-source-rtl" leading="اَلْعَرَبِيَّةُ " trailing=" hello word" />
+    </view>
+  );
+}
+
+export function BoringLayoutCase() {
+  return (
+    <view className="fixture-column boring-source-container">
+      <CompatibilityNote>
+        {"The public ReactLynx page cannot enable the retired enableTextBoringLayout host switch or text-vertical-align property. The ten visible inputs remain independently represented."}
+      </CompatibilityNote>
+      <text className="boring-row boring-nowrap">{"white-space nowrap"}</text>
+      <text className="boring-row boring-max-content">{"width max-content"}</text>
+      <text className="boring-row boring-nowrap boring-line-height-large">{"line-height 30"}</text>
+      <text className="boring-row boring-nowrap boring-line-height-small">{"line-height 10"}</text>
+      <text className="boring-row boring-nowrap boring-centered">{"centered width 100"}</text>
+      <text className="boring-row boring-nowrap boring-right">{"right width 100"}</text>
+      <text className="boring-row boring-nowrap">{"hello world你好"}</text>
+      <text className="boring-row boring-nowrap">
+        {"hello "}
+        <view className="boring-inline-view" />
+        {" world"}
+      </text>
+      <text className="boring-row boring-nowrap">{"legacy text vertical center input"}</text>
+      <text className="boring-row boring-empty">{"​"}</text>
+    </view>
+  );
+}
+
+function EventHitRow(
+  { label, modifier, onImage, onText, onView }: {
+    label: string;
+    modifier: string;
+    onImage: () => void;
+    onText: () => void;
+    onView: () => void;
+  },
+) {
+  return (
+    <view className="event-source-block">
+      <text className="event-source-label">{label}</text>
+      <text className={`event-source-line ${modifier}`}>
+        <view className="event-source-view" bindtap={onView} />
+        <image className="event-source-image" src={inlineImage} bindtap={onImage} />
+        <text className="event-source-text" bindtap={onText}>{"hello world"}</text>
+      </text>
+    </view>
+  );
+}
+
+export function EventWithPaddingCase() {
+  const [inlineTextClickCount, setInlineTextClickCount] = useState(0);
+  const [inlineImageClickCount, setInlineImageClickCount] = useState(0);
+  const [inlineViewClickCount, setInlineViewClickCount] = useState(0);
+  const handlers = {
+    onImage: () => setInlineImageClickCount(inlineImageClickCount + 1),
+    onText: () => setInlineTextClickCount(inlineTextClickCount + 1),
+    onView: () => setInlineViewClickCount(inlineViewClickCount + 1),
+  };
+
+  return (
+    <view className="fixture-column">
+      <text className="event-counts" lynx-test-tag="count">
+        <ValueBadge>{`view ${inlineViewClickCount}`}</ValueBadge>{" "}
+        <ValueBadge>{`image ${inlineImageClickCount}`}</ValueBadge>{" "}
+        <ValueBadge>{`text ${inlineTextClickCount}`}</ValueBadge>
+      </text>
+      <EventHitRow {...handlers} label="padding-left: 100" modifier="event-padding-left" />
+      <EventHitRow {...handlers} label="margin-left: 100" modifier="event-margin-left" />
+      <EventHitRow {...handlers} label="border-left: 100" modifier="event-border-left" />
+      <EventHitRow {...handlers} label="padding-top: 30" modifier="event-padding-top" />
+      <EventHitRow {...handlers} label="margin-top: 30" modifier="event-margin-top" />
+      <EventHitRow {...handlers} label="border-top: 30" modifier="event-border-top" />
+    </view>
+  );
+}
+
+export function FontFamilyWeightCase() {
+  return (
+    <view className="fixture-column">
+      <CompatibilityNote>
+        {"System font fallbacks replace private fonts while preserving the 800/400 weights and the nested italic regression structure."}
+      </CompatibilityNote>
+      <text className="font-source-800">{"font-weight: 800 中文"}</text>
+      <text className="font-source-400">{"font-weight: 400 中文"}</text>
+      <text className="font-source-display">{"444你好世界こんにちは季節"}</text>
+      <text className="font-source-question">
+        <text className="font-source-question-part">{"Who uncovers Grogu's name in "}</text>
+        <text className="font-source-question-part font-source-question-italic">{"The Mandalorian"}</text>
+        <text className="font-source-question-part">{"?"}</text>
+      </text>
+    </view>
+  );
+}
+
+function HyphenRow({ label, text, variant }: { label: string; text: string; variant: string }) {
+  return (
+    <view className="hyphen-source-row">
+      <text className="hyphen-source-label">{label}</text>
+      <text className={`hyphen-source-text ${variant}`}>{text}</text>
+    </view>
+  );
+}
+
+export function HyphensAutoCase() {
+  return (
+    <view className="fixture-column hyphen-source-container">
+      <HyphenRow label="hyphens on" text="An extraordinarily long English word!" variant="hyphens-on" />
+      <HyphenRow
+        label="hyphens on with soft hyphen"
+        text="An extra­ordinarily long English word!"
+        variant="hyphens-on"
+      />
+      <HyphenRow label="hyphens off" text="An extraordinarily long English word!" variant="hyphens-off" />
+      <HyphenRow
+        label="hyphens off with soft hyphen"
+        text="An extra­ordinarily long English word!"
+        variant="hyphens-off"
+      />
+    </view>
+  );
+}
+
+export function InlineElementAlignCenterCase() {
+  return (
+    <view className="inline-center-source-container">
+      <text className="inline-center-source-text" text-maxline="1">
+        {"测试文本 "}
+        <image className="inline-center-source-image" src={inlineImage} />
+        <view className="inline-center-source-view" />
+        {" 这是一段测试文本这是一段测试文本"}
+      </text>
+    </view>
+  );
+}

--- a/examples/text-composition/src/cases/InlineCases.tsx
+++ b/examples/text-composition/src/cases/InlineCases.tsx
@@ -1,0 +1,140 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { FixtureGroup } from "./shared.jsx";
+
+export function InlineTextCase() {
+  return (
+    <view className="fixture-column">
+      <FixtureGroup label="inline text concatenation">
+        <text className="inline-source-paragraph">
+          {"简单文本场景:"}
+          <text>{"[inline-text 1]"}</text>
+          <text>{"[inline-text 2]"}</text>
+        </text>
+      </FixtureGroup>
+
+      <FixtureGroup label="different size">
+        <text className="inline-source-paragraph">
+          {"简单文本场景:"}
+          <text className="inline-source-small">{"[inline-text 1]"}</text>
+          <text className="inline-source-large">{"[inline-text 2]"}</text>
+        </text>
+      </FixtureGroup>
+
+      <FixtureGroup label="different and gradient colors">
+        <text className="inline-source-paragraph">
+          {"简单文本场景:"}
+          <text className="inline-source-blue">{"[inline-text 1]"}</text>
+          <text className="inline-source-cyan">{"[inline-text 2]"}</text>
+        </text>
+        <text className="inline-source-paragraph">
+          {"inline-text gradient-color:"}
+          <text className="inline-source-blue">{"[inline-text 1]"}</text>
+          <text className="inline-source-gradient-right">{"[inline-text 2]"}</text>
+        </text>
+        <text className="inline-source-paragraph inline-source-outer-gradient inline-source-overflow-hidden">
+          {"color override hidden:"}
+          <text className="inline-source-gradient-left">{"[inline-text 1]"}</text>
+          <text>{"[inline-text 2]"}</text>
+        </text>
+        <text className="inline-source-paragraph inline-source-outer-gradient inline-source-overflow-visible">
+          {"color override visible:"}
+          <text className="inline-source-gradient-left">{"[inline-text 1]"}</text>
+          <text>{"[inline-text 2]"}</text>
+        </text>
+      </FixtureGroup>
+
+      <FixtureGroup label="different style">
+        <text className="inline-source-paragraph">
+          {"简单文本场景:"}
+          <text className="inline-source-italic">{"[inline-text 1]"}</text>
+          <text className="inline-source-line-through">{"[inline-text 2]"}</text>
+        </text>
+        <text className="inline-source-paragraph">{"简单文本场景"}</text>
+      </FixtureGroup>
+    </view>
+  );
+}
+
+function DecoratedInlineContent() {
+  return (
+    <>
+      {"你说的 "}
+      <text className="background-source-gradient">
+        {"a下面是一个示例代码，👨‍👩‍👧‍👦展示文本背景渐变色"}
+      </text>
+      <text className="background-source-rounded">{" 展示圆角背景渐变色"}</text>
+      <text className="background-source-dotted">{" 下划线和其他样式"}</text>
+      <view className="background-source-inline-view">
+        <text className="background-source-inline-view-text">{"这"}</text>
+      </view>
+    </>
+  );
+}
+
+export function InlineTextBackgroundImageCase() {
+  return (
+    <view className="fixture-column">
+      <FixtureGroup label="maxline 3 · paragraph line-height">
+        <text className="background-source-paragraph background-source-paragraph--line-height" text-maxline="3">
+          <DecoratedInlineContent />
+        </text>
+      </FixtureGroup>
+      <FixtureGroup label="maxline 3 · default line-height">
+        <text className="background-source-paragraph" text-maxline="3">
+          <DecoratedInlineContent />
+        </text>
+      </FixtureGroup>
+      <FixtureGroup label="maxline 2 · center">
+        <text className="background-source-paragraph background-source-center" text-maxline="2">
+          {"text-align:center; "}
+          <text className="background-source-gradient">{"custom background color; "}</text>
+          <text className="background-source-rounded">{"border radius background; "}</text>
+          <text className="background-source-dotted">{"dot line;"}</text>
+        </text>
+      </FixtureGroup>
+      <FixtureGroup label="maxline 2 · right · line-height 25">
+        <text
+          className="background-source-paragraph background-source-right background-source-paragraph--compact"
+          text-maxline="2"
+        >
+          {"text-align:right; "}
+          <text className="background-source-gradient">{"custom background color; "}</text>
+          <text className="background-source-rounded">{"border radius background; "}</text>
+          <text className="background-source-dotted">{"dot line;"}</text>
+        </text>
+      </FixtureGroup>
+      <FixtureGroup label="maxline 2 · center · ellipsis">
+        <text
+          className="background-source-paragraph background-source-center background-source-paragraph--compact background-source-ellipsis"
+          text-maxline="2"
+        >
+          {"text-align:center; "}
+          <text className="background-source-gradient">{"custom background color; 自定义背景颜色 "}</text>
+          <text className="background-source-rounded">{"border radius background; "}</text>
+          <text className="background-source-dotted">{"dot line; 自定义下划线自定义下划线"}</text>
+        </text>
+      </FixtureGroup>
+      <FixtureGroup label="maxline 3 · custom inline truncation">
+        <text
+          className="background-source-paragraph background-source-center background-source-ellipsis"
+          text-maxline="3"
+        >
+          {"text-align:center; "}
+          <text className="background-source-gradient">{"custom background color; 自定义背景颜色 "}</text>
+          <text className="background-source-rounded">{"border radius background; "}</text>
+          <text className="background-source-dotted">{"dot line; 自定义下划线自定义下划线 "}</text>
+          <text className="background-source-gradient">{"超长的文本内容超长的文本内容超长的文本内容"}</text>
+          <inline-truncation>
+            <text>
+              {"..."}
+              <text className="background-source-full">{"全文"}</text>
+            </text>
+          </inline-truncation>
+        </text>
+      </FixtureGroup>
+    </view>
+  );
+}

--- a/examples/text-composition/src/cases/LayoutCases.tsx
+++ b/examples/text-composition/src/cases/LayoutCases.tsx
@@ -1,0 +1,209 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { useState } from "@lynx-js/react";
+
+import { longParagraph } from "../mockData.js";
+import { BasicCase } from "./FoundationCases.jsx";
+import { InlineTextCase } from "./InlineCases.jsx";
+import { CompatibilityNote, FixtureGroup, ValueBadge } from "./shared.jsx";
+
+function StaticMultiLineMatrix() {
+  return (
+    <view className="fixture-column">
+      <FixtureGroup label="no text-maxline">
+        <text className="multiline-source-text">{longParagraph}</text>
+      </FixtureGroup>
+      <FixtureGroup label="text-maxline 2">
+        <text className="multiline-source-text" text-maxline="2">{longParagraph}</text>
+      </FixtureGroup>
+      <FixtureGroup label="text-maxline 4">
+        <text className="multiline-source-text" text-maxline="4">{longParagraph}</text>
+      </FixtureGroup>
+      <FixtureGroup label="white-space nowrap">
+        <view className="multiline-nowrap-window">
+          <text className="multiline-source-text multiline-nowrap">{longParagraph}</text>
+        </view>
+      </FixtureGroup>
+      <FixtureGroup label="text-maxline 4 · ellipsis">
+        <text className="multiline-source-text multiline-ellipsis" text-maxline="4">{longParagraph}</text>
+      </FixtureGroup>
+    </view>
+  );
+}
+
+export function LayerBasicCase() {
+  return (
+    <view className="fixture-column">
+      <CompatibilityNote>
+        {"The public rendering path replaces the source enableTextLayerRender switch. This page independently runs the complete visible basic matrix."}
+      </CompatibilityNote>
+      <BasicCase />
+    </view>
+  );
+}
+
+export function LayerInlineTextCase() {
+  return (
+    <view className="fixture-column">
+      <CompatibilityNote>
+        {"The public rendering path replaces the source enableTextLayerRender switch. This page independently runs the complete inline-text matrix."}
+      </CompatibilityNote>
+      <InlineTextCase />
+    </view>
+  );
+}
+
+export function LayerMultiLineCase() {
+  return (
+    <view className="fixture-column">
+      <CompatibilityNote>
+        {"The public rendering path replaces the source enableTextLayerRender switch. Unlimited, two-line, four-line, nowrap, and ellipsis inputs remain."}
+      </CompatibilityNote>
+      <StaticMultiLineMatrix />
+    </view>
+  );
+}
+
+export function MultiLineCase() {
+  const [limit, setLimit] = useState("1");
+
+  const onTap = () => {
+    if (limit === "") {
+      setLimit("1");
+    } else {
+      setLimit("");
+    }
+  };
+
+  return (
+    <view className="fixture-column">
+      <FixtureGroup label="tap toggles text-maxline between 1 and empty">
+        <text className="multiline-state">
+          <ValueBadge>{`limit: ${limit === "" ? "empty" : limit}`}</ValueBadge>
+        </text>
+        <text
+          className="multiline-source-text multiline-ellipsis"
+          text-maxline={limit}
+          bindtap={onTap}
+          lynx-test-tag="maxline-test"
+        >
+          {longParagraph}
+        </text>
+      </FixtureGroup>
+      <FixtureGroup label="text-maxline 2">
+        <text className="multiline-source-text" text-maxline="2">{longParagraph}</text>
+      </FixtureGroup>
+      <FixtureGroup label="text-maxline 4">
+        <text className="multiline-source-text" text-maxline="4">{longParagraph}</text>
+      </FixtureGroup>
+      <FixtureGroup label="white-space nowrap">
+        <view className="multiline-nowrap-window">
+          <text className="multiline-source-text multiline-nowrap">{longParagraph}</text>
+        </view>
+      </FixtureGroup>
+      <FixtureGroup label="text-maxline 4 · ellipsis">
+        <text className="multiline-source-text multiline-ellipsis" text-maxline="4">{longParagraph}</text>
+      </FixtureGroup>
+    </view>
+  );
+}
+
+const fontRows = [
+  ["font-source-f1", "public serif, fallback sans"],
+  ["font-source-f2", "missing first, public serif second"],
+  ["font-source-f3", "empty family"],
+  ["font-source-f4", "empty first, public serif second"],
+  ["font-source-f5", "public serif first, empty second"],
+  ["font-source-f6", "public monospace"],
+  ["font-source-f7", "public monospace, public serif"],
+];
+
+export function MultipleFontFamilyCase() {
+  return (
+    <view className="fixture-column">
+      <CompatibilityNote>
+        {"Offline system serif and monospace fonts replace two private network fonts while preserving seven fallback orders and empty-family boundaries."}
+      </CompatibilityNote>
+      {fontRows.map(([className, label], index) => (
+        <view className="font-source-row" key={className}>
+          <text className="font-source-label">{`f${index + 1} · ${label}`}</text>
+          <text className={`font-source-sample ${className}`}>{"test 测试"}</text>
+        </view>
+      ))}
+    </view>
+  );
+}
+
+export function TextAlignRightBadCase() {
+  return (
+    <view className="align-right-source-root">
+      <view className="align-right-source-spacer" />
+      <view className="align-right-source-content">
+        <text className="align-right-source-outer" lynx-test-tag="container">
+          <text className="align-right-source-inner">
+            {"aaa,122****2222,测试文本5555测试文本测试文本测试文本测试文本"}
+          </text>
+        </text>
+      </view>
+    </view>
+  );
+}
+
+export function TextIndentCase() {
+  return (
+    <view className="fixture-column text-indent-source-root">
+      <text className="text-indent-source text-indent-source--percent">
+        <text>{"text-indent 10%"}</text>
+      </text>
+      <text className="text-indent-source text-indent-source--small">{"text-indent 10px"}</text>
+      <text className="text-indent-source">{"text-indent no"}</text>
+      <text className="text-indent-source text-indent-source--max text-indent-source--large">{"text-indent 50px"}</text>
+      <text className="text-indent-source text-indent-source--large">
+        {"fixed width text with text-indent 50px and multiline"}
+      </text>
+    </view>
+  );
+}
+
+export function TransformCase() {
+  return (
+    <view className="transform-source-root" lynx-test-tag="transform">
+      <view className="transform-source-outer">
+        <text className="transform-source-text transform-source-rotate">{"abcde"}</text>
+      </view>
+      <view className="transform-source-outer">
+        <text className="transform-source-text transform-source-scale">{"abcde"}</text>
+      </view>
+    </view>
+  );
+}
+
+export function WhiteSpaceCase() {
+  return (
+    <view className="fixture-column white-space-source-root">
+      <text className="white-space-source-title">{"white-space: normal"}</text>
+      <text className="white-space-source-item white-space-source-normal">
+        {"But ere she from the church-door stepped She smiled and told us why: 'It was a wicked woman's curse,' Quoth she, 'and what care I?' She smiled, and smiled, and passed it off Ere from the door she stept—"}
+      </text>
+      <text className="white-space-source-title">{"white-space: nowrap"}</text>
+      <text className="white-space-source-item white-space-source-nowrap">{"But\n—"}</text>
+    </view>
+  );
+}
+
+export function WordBreakKeepAllCase() {
+  return (
+    <view className="fixture-column word-break-source-root">
+      <text className="word-break-source-label">{"keep-all on:"}</text>
+      <text className="word-break-source-text word-break-source-on">
+        {"english 中文文本 한국어한 ブレーク english"}
+      </text>
+      <text className="word-break-source-label">{"keep-all off:"}</text>
+      <text className="word-break-source-text word-break-source-off">
+        {"english 中文文本 한국어한 ブレーク english"}
+      </text>
+    </view>
+  );
+}

--- a/examples/text-composition/src/cases/TruncationCases.tsx
+++ b/examples/text-composition/src/cases/TruncationCases.tsx
@@ -1,0 +1,426 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { type ReactNode, useState } from "@lynx-js/react";
+
+import { inlineImage } from "../mockData.js";
+import { FixtureGroup, ValueBadge } from "./shared.jsx";
+
+const InteractiveInlineTruncation = "inline-truncation" as unknown as (
+  props: {
+    bindtap: () => void;
+    children: ReactNode;
+  },
+) => ReactNode;
+
+const longEnglish =
+  "this is a test text. this is a test text. this is a test text. this is a test text. this is a test text. this is a test text.";
+const longArabic = "هذا نص للاختبار هذا نص للاختبار هذا نص للاختبار هذا نص للاختبار هذا نص للاختبار هذا نص للاختبار";
+
+function BasicTail({ percentage = false }: { percentage?: boolean }) {
+  return (
+    <inline-truncation>
+      <view
+        className={percentage ? "trunc-basic-tail-view trunc-basic-tail-view--percentage" : "trunc-basic-tail-view"}
+      />
+      <text className="trunc-basic-tail-text">{"inline truncation"}</text>
+    </inline-truncation>
+  );
+}
+
+function TruncationHeightRow(
+  { className, content = longEnglish, label, tail = true }: {
+    className: string;
+    content?: string;
+    label: string;
+    tail?: boolean;
+  },
+) {
+  return (
+    <view className="trunc-basic-row">
+      <text className="trunc-basic-label">{label}</text>
+      <text className={`trunc-basic-text ${className}`}>
+        {content}
+        {tail && <BasicTail />}
+      </text>
+    </view>
+  );
+}
+
+export function InlineTruncationCase() {
+  return (
+    <view className="fixture-column">
+      <TruncationHeightRow className="trunc-height-30" label="height 30 · line-height 20" />
+      <TruncationHeightRow className="trunc-height-10" label="height 10 · flatten false tail" />
+      <view className="trunc-basic-row">
+        <text className="trunc-basic-label">{"height 20 · short text tail"}</text>
+        <text className="trunc-basic-text trunc-height-20">
+          {"this is a test text."}
+          <inline-truncation>
+            <text>{"inline truncation"}</text>
+          </inline-truncation>
+        </text>
+      </view>
+      <TruncationHeightRow
+        className="trunc-height-25"
+        content="this is a test text."
+        label="height 25 · short text and view tail"
+      />
+      <TruncationHeightRow className="trunc-height-20" content="" label="height 20 · empty content" />
+      <TruncationHeightRow
+        className="trunc-height-10 trunc-overflow-visible"
+        content="this is a test text."
+        label="height 10 · overflow visible"
+        tail={false}
+      />
+      <TruncationHeightRow className="trunc-height-10 trunc-ellipsis" label="height 10 · ellipsis" tail={false} />
+      <TruncationHeightRow
+        className="trunc-height-25 trunc-ellipsis trunc-no-line-height"
+        label="height 25 · ellipsis · default line-height"
+        tail={false}
+      />
+      <TruncationHeightRow className="trunc-height-40" label="height 40 · custom tail" />
+      <TruncationHeightRow className="trunc-height-50" label="height 50 · custom tail" />
+      <view className="trunc-basic-row">
+        <text className="trunc-basic-label">{"maxline 2 · 50% inline view"}</text>
+        <text className="trunc-basic-text trunc-maxline-two" text-maxline="2">
+          {longEnglish}
+          <BasicTail percentage />
+        </text>
+      </view>
+      <FixtureGroup label="flex siblings · heights 30 / 40 / 50">
+        <view className="trunc-basic-flex-row">
+          <text className="trunc-basic-text trunc-height-30">
+            {longEnglish}
+            <BasicTail />
+          </text>
+          <text className="trunc-basic-text trunc-height-40">
+            {longEnglish}
+            <BasicTail />
+          </text>
+          <text className="trunc-basic-text trunc-height-50">
+            {longEnglish}
+            <BasicTail />
+          </text>
+        </view>
+      </FixtureGroup>
+    </view>
+  );
+}
+
+function EventColor({ active }: { active: boolean }) {
+  return <ValueBadge>{active ? "red / tapped" : "black / idle"}</ValueBadge>;
+}
+
+export function InlineTruncationEventCase() {
+  const [ltrTruncation, setLtrTruncation] = useState(false);
+  const [ltrImage, setLtrImage] = useState(false);
+  const [ltrView, setLtrView] = useState(false);
+  const [ltrText, setLtrText] = useState(false);
+  const [rtlTruncation, setRtlTruncation] = useState(false);
+  const [rtlImage, setRtlImage] = useState(false);
+  const [rtlView, setRtlView] = useState(false);
+  const [rtlText, setRtlText] = useState(false);
+
+  return (
+    <view className="fixture-column">
+      <FixtureGroup label="LTR · event on inline-truncation">
+        <EventColor active={ltrTruncation} />
+        <text
+          className={ltrTruncation ? "trunc-event-text trunc-event-text--active" : "trunc-event-text"}
+          text-maxline="1"
+        >
+          {"this is this is "}
+          <view>
+            <text className="trunc-event-nested">{"this is"}</text>
+          </view>
+          {" 这个文本 "}
+          <text className="trunc-event-nested">
+            {"this is "}
+            <image className="trunc-event-image" src={inlineImage} />
+          </text>
+          {" this is a test text."}
+          <InteractiveInlineTruncation bindtap={() => setLtrTruncation(true)}>
+            <view className="trunc-event-view" />
+            <text>{"inline truncation"}</text>
+          </InteractiveInlineTruncation>
+        </text>
+      </FixtureGroup>
+
+      <FixtureGroup label="LTR · child view / image / text events">
+        <text className={ltrView ? "trunc-event-text trunc-event-text--active" : "trunc-event-text"} text-maxline="1">
+          {longEnglish}
+          <inline-truncation>
+            <view className="trunc-event-view trunc-event-view--large" bindtap={() => setLtrView(true)} />
+          </inline-truncation>
+        </text>
+        <EventColor active={ltrView} />
+        <text className={ltrImage ? "trunc-event-text trunc-event-text--active" : "trunc-event-text"} text-maxline="1">
+          {longEnglish}
+          <inline-truncation>
+            <image className="trunc-event-tail-image" src={inlineImage} bindtap={() => setLtrImage(true)} />
+          </inline-truncation>
+        </text>
+        <EventColor active={ltrImage} />
+        <text className={ltrText ? "trunc-event-text trunc-event-text--active" : "trunc-event-text"} text-maxline="1">
+          {longEnglish}
+          <inline-truncation>
+            <text bindtap={() => setLtrText(true)}>{"inline truncation"}</text>
+          </inline-truncation>
+        </text>
+        <EventColor active={ltrText} />
+      </FixtureGroup>
+
+      <FixtureGroup label="RTL · event on inline-truncation">
+        <EventColor active={rtlTruncation} />
+        <text
+          className={rtlTruncation
+            ? "trunc-event-text trunc-event-text--rtl trunc-event-text--active"
+            : "trunc-event-text trunc-event-text--rtl"}
+          text-maxline="1"
+        >
+          {longArabic}
+          <InteractiveInlineTruncation bindtap={() => setRtlTruncation(true)}>
+            <text>{"اقتطاع مخصص"}</text>
+            <view className="trunc-event-view" />
+            <image className="trunc-event-image-small" src={inlineImage} />
+          </InteractiveInlineTruncation>
+        </text>
+      </FixtureGroup>
+
+      <FixtureGroup label="RTL · child view / image / text events">
+        <text
+          className={rtlView
+            ? "trunc-event-text trunc-event-text--rtl trunc-event-text--active"
+            : "trunc-event-text trunc-event-text--rtl"}
+          text-maxline="1"
+        >
+          {longArabic}
+          <inline-truncation>
+            <view className="trunc-event-view" bindtap={() => setRtlView(true)} />
+          </inline-truncation>
+        </text>
+        <EventColor active={rtlView} />
+        <text
+          className={rtlImage
+            ? "trunc-event-text trunc-event-text--rtl trunc-event-text--active"
+            : "trunc-event-text trunc-event-text--rtl"}
+          text-maxline="1"
+        >
+          {longArabic}
+          <inline-truncation>
+            <image className="trunc-event-image-small" src={inlineImage} bindtap={() => setRtlImage(true)} />
+          </inline-truncation>
+        </text>
+        <EventColor active={rtlImage} />
+        <text
+          className={rtlText
+            ? "trunc-event-text trunc-event-text--rtl trunc-event-text--active"
+            : "trunc-event-text trunc-event-text--rtl"}
+          text-maxline="1"
+        >
+          {longArabic}
+          <inline-truncation>
+            <text bindtap={() => setRtlText(true)}>{"اقتطاع مخصص"}</text>
+          </inline-truncation>
+        </text>
+        <EventColor active={rtlText} />
+      </FixtureGroup>
+    </view>
+  );
+}
+
+type RtlTailKind = "text" | "view" | "image" | "composite" | "latin" | "vertical" | "view-image";
+
+function RtlTail({ kind }: { kind: RtlTailKind }) {
+  if (kind === "view") {
+    return (
+      <inline-truncation>
+        <view className="rtl-source-tail-view" />
+      </inline-truncation>
+    );
+  }
+  if (kind === "image") {
+    return (
+      <inline-truncation>
+        <image className="rtl-source-tail-image" src={inlineImage} />
+      </inline-truncation>
+    );
+  }
+  if (kind === "composite") {
+    return (
+      <inline-truncation>
+        <text>{"اقتطاع مخصص"}</text>
+        <view className="rtl-source-tail-view" />
+        <image className="rtl-source-tail-image" src={inlineImage} />
+      </inline-truncation>
+    );
+  }
+  if (kind === "latin") {
+    return (
+      <inline-truncation>
+        <text>{"...truncation"}</text>
+      </inline-truncation>
+    );
+  }
+  if (kind === "vertical") {
+    return (
+      <inline-truncation>
+        <view className="rtl-source-tail-view rtl-source-tail-view--raised" />
+        <image className="rtl-source-tail-image rtl-source-tail-image--lowered" src={inlineImage} />
+      </inline-truncation>
+    );
+  }
+  if (kind === "view-image") {
+    return (
+      <inline-truncation>
+        <view className="rtl-source-tail-view" />
+        <image className="rtl-source-tail-image" src={inlineImage} />
+      </inline-truncation>
+    );
+  }
+  return (
+    <inline-truncation>
+      <text>{"اقتطاع مخصص"}</text>
+    </inline-truncation>
+  );
+}
+
+function RtlSourceRow(
+  { children, className = "", kind = "text", label, maxline = "1" }: {
+    children: ReactNode;
+    className?: string;
+    kind?: RtlTailKind;
+    label: string;
+    maxline?: string;
+  },
+) {
+  return (
+    <view className="rtl-source-row">
+      <text className="rtl-source-label">{label}</text>
+      <text className={`rtl-source-text ${className}`} text-maxline={maxline}>
+        {children}
+        <RtlTail kind={kind} />
+      </text>
+    </view>
+  );
+}
+
+export function InlineTruncationRtlCase() {
+  return (
+    <view className="fixture-column">
+      <RtlSourceRow className="rtl-source-direction" label="rtl · maxline 1">{longArabic}</RtlSourceRow>
+      <RtlSourceRow label="auto direction · maxline 1">{longArabic}</RtlSourceRow>
+      <RtlSourceRow className="rtl-source-direction rtl-source-ellipsis" label="rtl · ellipsis · maxline 1">
+        {longArabic}
+      </RtlSourceRow>
+      <RtlSourceRow className="rtl-source-ellipsis" label="auto · ellipsis · maxline 1">{longArabic}</RtlSourceRow>
+      <RtlSourceRow className="rtl-source-ellipsis" label="text tail · maxline 2" maxline="2">
+        {longArabic}
+      </RtlSourceRow>
+      <RtlSourceRow className="rtl-source-ellipsis" kind="view" label="view tail · maxline 2" maxline="2">
+        {longArabic}
+      </RtlSourceRow>
+      <RtlSourceRow className="rtl-source-ellipsis" kind="image" label="image tail · maxline 2" maxline="2">
+        {longArabic}
+      </RtlSourceRow>
+      <RtlSourceRow className="rtl-source-ltr rtl-source-ellipsis" label="mixed copy · ltr · Arabic tail" maxline="2">
+        {"this is a للاختبا long test text this is a long test text this is a long test text"}
+      </RtlSourceRow>
+      <RtlSourceRow
+        className="rtl-source-direction rtl-source-ellipsis"
+        label="Latin copy · rtl · Arabic tail"
+        maxline="2"
+      >
+        {longEnglish}
+      </RtlSourceRow>
+      <RtlSourceRow className="rtl-source-ltr rtl-source-ellipsis" label="Latin copy · ltr · Arabic tail" maxline="2">
+        {longEnglish}
+      </RtlSourceRow>
+      <RtlSourceRow
+        className="rtl-source-direction rtl-source-ellipsis"
+        kind="latin"
+        label="Arabic copy · rtl · Latin tail"
+        maxline="2"
+      >
+        {longArabic}
+      </RtlSourceRow>
+      <RtlSourceRow
+        className="rtl-source-direction rtl-source-ellipsis"
+        kind="latin"
+        label="Latin copy · rtl · Latin tail"
+        maxline="2"
+      >
+        {longEnglish}
+      </RtlSourceRow>
+      <RtlSourceRow className="rtl-source-ellipsis" kind="composite" label="composite text/view/image tail">
+        {longArabic}
+      </RtlSourceRow>
+      <RtlSourceRow className="rtl-source-ellipsis" kind="latin" label="emoji copy · Latin tail">
+        {"😄😅😄😅😄😅😄😅😄😅😄😅😄😅😄😅😄😅😄😅😄😅😄😅"}
+      </RtlSourceRow>
+      <RtlSourceRow
+        className="rtl-source-ellipsis"
+        kind="vertical"
+        label="positive / negative vertical-align"
+        maxline="2"
+      >
+        {longArabic}
+      </RtlSourceRow>
+      <RtlSourceRow
+        className="rtl-source-ellipsis"
+        kind="view-image"
+        label="inline body view/image and tail view/image"
+        maxline="2"
+      >
+        {"هذا نص "}
+        <view className="rtl-source-tail-view" />
+        {" للاختبار هذا نص "}
+        <view className="rtl-source-tail-view" />
+        {longArabic}
+        <image className="rtl-source-tail-image" src={inlineImage} />
+      </RtlSourceRow>
+    </view>
+  );
+}
+
+export function InlineTruncationUpdateCase() {
+  const [control, setControl] = useState(true);
+  const [line, setLine] = useState("1");
+
+  const onTap = () => {
+    setControl(!control);
+    setLine("-1");
+  };
+
+  return (
+    <view className="fixture-column trunc-update-root" bindtap={onTap}>
+      <text className="trunc-update-status">
+        <ValueBadge>{`control ${control}`}</ValueBadge> <ValueBadge>{`line ${line}`}</ValueBadge>
+      </text>
+      <text className="trunc-update-primary" text-maxline="1">
+        {"这段文本内容过长，会发生截断"}
+        {control && (
+          <inline-truncation>
+            <text className="trunc-update-tail-text">{"truncation"}</text>
+            <view>
+              <text>{"haha"}</text>
+            </view>
+          </inline-truncation>
+        )}
+      </text>
+      <text className="trunc-update-secondary" text-maxline={line}>
+        {[0, 1, 2, 3, 4].map((item) => (
+          <view className="trunc-update-item" key={`${item}`}>
+            <text className="trunc-update-item-text">{"hello"}</text>
+          </view>
+        ))}
+        <inline-truncation>
+          <view className="trunc-update-green-tail" />
+        </inline-truncation>
+      </text>
+      <text className="trunc-update-hint">{"Tap the content: invert control and set line to -1"}</text>
+    </view>
+  );
+}

--- a/examples/text-composition/src/cases/registry.tsx
+++ b/examples/text-composition/src/cases/registry.tsx
@@ -1,0 +1,180 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import {
+  BadCase,
+  BasicCase,
+  BidiTextCase,
+  BoringLayoutCase,
+  EventWithPaddingCase,
+  FontFamilyWeightCase,
+  HyphensAutoCase,
+  InlineElementAlignCenterCase,
+} from "./FoundationCases.jsx";
+import { InlineTextBackgroundImageCase, InlineTextCase } from "./InlineCases.jsx";
+import {
+  LayerBasicCase,
+  LayerInlineTextCase,
+  LayerMultiLineCase,
+  MultiLineCase,
+  MultipleFontFamilyCase,
+  TextAlignRightBadCase,
+  TextIndentCase,
+  TransformCase,
+  WhiteSpaceCase,
+  WordBreakKeepAllCase,
+} from "./LayoutCases.jsx";
+import {
+  InlineTruncationCase,
+  InlineTruncationEventCase,
+  InlineTruncationRtlCase,
+  InlineTruncationUpdateCase,
+} from "./TruncationCases.jsx";
+
+export const sourceCases = [
+  {
+    name: "bad-case",
+    title: "Historical regression collection",
+    note: "Nested components, shared gradient state, overflow, maxlength, and decoration.",
+    render: () => <BadCase />,
+  },
+  {
+    name: "basic",
+    title: "Basic text styling",
+    note: "Alignment, the complete weight matrix, font style, decoration, and single/multiple shadows.",
+    render: () => <BasicCase />,
+  },
+  {
+    name: "bidi-text",
+    title: "Bidirectional text and inline views",
+    note: "Five auto/LTR/RTL mixed-direction and single-line truncation inputs.",
+    render: () => <BidiTextCase />,
+  },
+  {
+    name: "boring-layout",
+    title: "Boring layout boundaries",
+    note: "Nowrap, max-content, line height, alignment, empty text, and inline views.",
+    render: () => <BoringLayoutCase />,
+  },
+  {
+    name: "event-with-padding",
+    title: "Inline element hit regions",
+    note: "Six horizontal and vertical padding, margin, and border hit regions.",
+    render: () => <EventWithPaddingCase />,
+  },
+  {
+    name: "font-family-weight",
+    title: "Font family, weight, and nested italics",
+    note: "Preserves the 800/400 weights and regression sentence with public font fallbacks.",
+    render: () => <FontFamilyWeightCase />,
+  },
+  {
+    name: "hyphens-auto",
+    title: "Automatic hyphenation",
+    note: "Four auto/none and with/without soft-hyphen comparisons.",
+    render: () => <HyphensAutoCase />,
+  },
+  {
+    name: "inline-element-align-center",
+    title: "Centered inline images and views",
+    note: "Continuous text/image/view measurement inside a single-line truncated paragraph.",
+    render: () => <InlineElementAlignCenterCase />,
+  },
+  {
+    name: "inline-text",
+    title: "Nested text styling",
+    note: "Concatenation, font sizes, solid/gradient color inheritance, overrides, and distinct styles.",
+    render: () => <InlineTextCase />,
+  },
+  {
+    name: "inline-text-background-image",
+    title: "Nested text backgrounds",
+    note: "Six maxline, alignment, line-height, background, and custom truncation combinations.",
+    render: () => <InlineTextBackgroundImageCase />,
+  },
+  {
+    name: "inline-truncation",
+    title: "Custom truncation size boundaries",
+    note: "Height, line-height, overflow, empty content, percentage tails, and flex siblings.",
+    render: () => <InlineTruncationCase />,
+  },
+  {
+    name: "inline-truncation-event",
+    title: "Custom truncation events",
+    note: "Eight independent truncation/view/image/text states under LTR and RTL.",
+    render: () => <InlineTruncationEventCase />,
+  },
+  {
+    name: "inline-truncation-rtl",
+    title: "RTL custom truncation matrix",
+    note: "Sixteen direction, maxline, tail type, emoji, and vertical-align inputs.",
+    render: () => <InlineTruncationRtlCase />,
+  },
+  {
+    name: "inline-truncation-update",
+    title: "Runtime truncation updates",
+    note: "A tap inverts control and fixes the second paragraph maxline to -1.",
+    render: () => <InlineTruncationUpdateCase />,
+  },
+  {
+    name: "layer-basic",
+    title: "Layer renderer basic matrix",
+    note: "Runs the complete visible basic inputs independently and records the retired host-switch boundary.",
+    render: () => <LayerBasicCase />,
+  },
+  {
+    name: "layer-inline-text",
+    title: "Layer renderer nested text",
+    note: "Runs the complete visible inline-text inputs independently.",
+    render: () => <LayerInlineTextCase />,
+  },
+  {
+    name: "layer-multi-line",
+    title: "Layer renderer multiline text",
+    note: "Unlimited, two-line, four-line, nowrap, and ellipsis inputs.",
+    render: () => <LayerMultiLineCase />,
+  },
+  {
+    name: "multi-line",
+    title: "Multiline text and dynamic maxline",
+    note: "Preserves the source tap state machine between 1 and empty plus four static comparisons.",
+    render: () => <MultiLineCase />,
+  },
+  {
+    name: "multiple-font-family",
+    title: "Multiple font fallback orders",
+    note: "Preserves seven orders and empty-family boundaries with public font substitutes.",
+    render: () => <MultipleFontFamilyCase />,
+  },
+  {
+    name: "text-align-right-bad-case",
+    title: "Nested right-alignment regression input",
+    note: "Fixed sibling width, outer margin/border, and inner text-align:right.",
+    render: () => <TextAlignRightBadCase />,
+  },
+  {
+    name: "text-indent",
+    title: "First-line indent matrix",
+    note: "Five percentage, small, none, large, and max-content indent inputs.",
+    render: () => <TextIndentCase />,
+  },
+  {
+    name: "transform",
+    title: "Text transform",
+    note: "Two inputs covering 5rad rotation, transform origin, and 0.5 scaling.",
+    render: () => <TransformCase />,
+  },
+  {
+    name: "white-space",
+    title: "White-space comparison",
+    note: "Long normal text and nowrap text containing a source newline.",
+    render: () => <WhiteSpaceCase />,
+  },
+  {
+    name: "word-break-keep-all",
+    title: "Multilingual word breaking",
+    note: "Keep-all and normal comparisons using the same multilingual copy.",
+    render: () => <WordBreakKeepAllCase />,
+  },
+] as const;

--- a/examples/text-composition/src/cases/shared.tsx
+++ b/examples/text-composition/src/cases/shared.tsx
@@ -1,0 +1,29 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { PropsWithChildren } from "@lynx-js/react";
+
+export function FixtureGroup(
+  { children, label }: PropsWithChildren<{ label: string }>,
+) {
+  return (
+    <view className="fixture-group">
+      <text className="fixture-label">{label}</text>
+      <view className="fixture-group-content">{children}</view>
+    </view>
+  );
+}
+
+export function CompatibilityNote({ children }: PropsWithChildren) {
+  return (
+    <view className="compatibility-note">
+      <text className="compatibility-note-title">{"PUBLIC COMPATIBILITY"}</text>
+      <text className="compatibility-note-copy">{children}</text>
+    </view>
+  );
+}
+
+export function ValueBadge({ children }: PropsWithChildren) {
+  return <text className="value-badge">{children}</text>;
+}

--- a/examples/text-composition/src/components/CaseGallery.tsx
+++ b/examples/text-composition/src/components/CaseGallery.tsx
@@ -1,0 +1,59 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { useState } from "@lynx-js/react";
+
+import { sourceCases } from "../cases/registry.jsx";
+
+export function CaseGallery() {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const activeCase = sourceCases[activeIndex];
+  const caseNumber = `${activeIndex + 1}`.padStart(2, "0");
+  const goPrevious = () => setActiveIndex((activeIndex - 1 + sourceCases.length) % sourceCases.length);
+  const goNext = () => setActiveIndex((activeIndex + 1) % sourceCases.length);
+
+  return (
+    <view className="case-page" lynx-test-tag="text-composition-page">
+      <view className="case-navigator">
+        <view className="case-navigator-copy">
+          <text className="case-progress">{`${caseNumber} / ${sourceCases.length}`}</text>
+          <text className="case-source-name" lynx-test-tag="active-case-name">{activeCase.name}</text>
+          <text className="case-source-title">{activeCase.title}</text>
+          <text className="case-source-note">{activeCase.note}</text>
+        </view>
+        <view className="case-navigation-controls">
+          <view className="case-navigation-button" bindtap={goPrevious} lynx-test-tag="previous-case">
+            <text className="case-navigation-button-text">{"Previous"}</text>
+          </view>
+          <view
+            className="case-navigation-button case-navigation-button--primary"
+            bindtap={goNext}
+            lynx-test-tag="next-case"
+          >
+            <text className="case-navigation-button-text case-navigation-button-text--primary">{"Next"}</text>
+          </view>
+        </view>
+      </view>
+      <scroll-view
+        className="case-scroll"
+        key={activeCase.name}
+        scroll-orientation="vertical"
+        lynx-test-tag="active-case-scroll"
+      >
+        <view className="case-stage" lynx-test-tag={`case-${activeCase.name}`}>
+          <view className="case-stage-heading">
+            <text className="case-stage-kicker">{"SOURCE PARITY FIXTURE"}</text>
+            <text className="case-stage-id">{`${caseNumber}-${activeCase.name}`}</text>
+          </view>
+          {activeCase.render()}
+          <view className="case-stage-footer">
+            <text className="case-stage-footer-text">
+              {"This page renders one source case. Use the controls above to switch cases."}
+            </text>
+          </view>
+        </view>
+      </scroll-view>
+    </view>
+  );
+}

--- a/examples/text-composition/src/components/TextCompositionArticle.tsx
+++ b/examples/text-composition/src/components/TextCompositionArticle.tsx
@@ -1,0 +1,47 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { useState } from "@lynx-js/react";
+
+import { article, inlineImage } from "../mockData.js";
+
+export function TextCompositionArticle() {
+  const [notice, setNotice] = useState("Tap an inline element to verify its independent event region");
+
+  return (
+    <view className="article-card">
+      <text className="eyebrow">{article.eyebrow}</text>
+      <text className="article-title">{article.title}</text>
+      <text className="article-body" lynx-test-tag="text-composition-owner">
+        {article.lead}
+        <text className="article-highlight">{article.highlight}</text>
+        {article.tail}{" "}
+        <image
+          className="inline-image inline-image--center"
+          src={inlineImage}
+          bindtap={() => setNotice("Tapped the inline image")}
+          lynx-test-tag="inline-image"
+        />{" "}
+        <view
+          className="inline-chip inline-chip--center"
+          bindtap={() => setNotice("Tapped the composite inline badge")}
+          lynx-test-tag="inline-view"
+        >
+          <text className="inline-chip-dot">{"●"}</text>
+          <text className="inline-chip-label">{"Low"}</text>
+        </view>{" "}
+        <text
+          className="article-link"
+          bindtap={() => setNotice("Tapped the inline text action")}
+          lynx-test-tag="inline-text"
+        >
+          {article.action}
+        </text>
+      </text>
+      <view className="event-notice">
+        <text className="event-notice-text">{notice}</text>
+      </view>
+    </view>
+  );
+}

--- a/examples/text-composition/src/index.tsx
+++ b/examples/text-composition/src/index.tsx
@@ -1,0 +1,13 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root } from "@lynx-js/react";
+
+import { App } from "./App.jsx";
+
+root.render(<App />);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/text-composition/src/mockData.ts
+++ b/examples/text-composition/src/mockData.ts
@@ -1,0 +1,31 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export const article = {
+  eyebrow: "WEEKLY FIELD NOTES",
+  title: "Let images, badges, and copy share one layout flow",
+  lead:
+    "After the rain stopped, an editor followed the old stone path uphill. Moss beside the trail caught the morning light, while ",
+  highlight: "a newly fallen ginkgo leaf",
+  tail:
+    " rested on the damp stones. Farther ahead, a wooden sign reminded visitors to slow down, and the entire paragraph wrapped naturally with the container.",
+  action: "View route",
+};
+
+export const longParagraph =
+  "永和九年，岁在癸丑，暮春之初，会于会稽山阴之兰亭，修禊事也。群贤毕至，少长咸集。此地有崇山峻岭，茂林修竹，又有清流激湍，映带左右，引以为流觞曲水，列坐其次。虽无丝竹管弦之盛，一觞一咏，亦足以畅叙幽情。";
+
+export const truncationText =
+  "This continuous passage verifies custom truncation. When the container narrows or the font grows, the outer text still owns measurement and places an interactive action at the end.";
+
+export const bidiSamples = {
+  mixed: "اَلْعَرَبِيَّةُ hello world 这是混合方向文本",
+  rtl: "هذا نص للاختبار مع صورة وعلامة داخل السطر",
+  emoji: "😄😅😄😅😄😅😄😅😄😅😄😅😄😅😄😅",
+};
+
+// A deterministic transparent pixel lets the example exercise a real nested
+// image without a network request. Its visible treatment comes from CSS.
+export const inlineImage =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";

--- a/examples/text-composition/src/rspeedy-env.d.ts
+++ b/examples/text-composition/src/rspeedy-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@lynx-js/rspeedy/client" />

--- a/examples/text-composition/tsconfig.json
+++ b/examples/text-composition/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "@lynx-js/react",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "strict": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+  },
+  "exclude": [
+    "dist/",
+  ],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1590,6 +1590,31 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
 
+  examples/text-composition:
+    dependencies:
+      '@lynx-js/react':
+        specifier: 'catalog:'
+        version: 0.123.1(@lynx-js/types@4.1.0)(@types/react@18.3.28)
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.6.0(@lynx-js/rspeedy@0.16.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.7(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.101.3))
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.18.1(@lynx-js/lynx-core@0.1.4)(@lynx-js/react@0.123.1(@lynx-js/types@4.1.0)(@types/react@18.3.28))(tslib@2.8.1)
+      '@lynx-js/rspeedy':
+        specifier: 'catalog:'
+        version: 0.16.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.7(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.101.3)
+      '@lynx-js/types':
+        specifier: 'catalog:'
+        version: 4.1.0
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+
   examples/textarea:
     dependencies:
       '@lynx-js/react':


### PR DESCRIPTION
## Summary

- add `@lynx-example/text-composition` with 24 independently navigable cases migrated from the legacy text platform fixtures
- preserve the source case matrices, events, state transitions, bidirectional text, truncation, wrapping, font fallback, and inline text/image/view coverage
- add a production-oriented text composition example and a Lynx development guide
- include a reusable `text-composition` coding skill
- register `text-composition` in the repository-level example index
- add package metadata, lockfile entries, changelog, and changeset

## Why

The existing text regression fixtures are not available as a minimal public ReactLynx example. This change makes their coverage runnable and reviewable while documenting the correct Lynx model: one outer `<text>` owns continuous measurement and natural wrapping, with differentiated text, images, and atomic views nested inline.

Historical host-only renderer switches and private resources are replaced with public deterministic equivalents. The affected cases and the guide explicitly document those compatibility boundaries.

## Developer impact

Developers can run each source case independently through the in-example navigator and use `README.md` or `SKILL.md` when implementing or reviewing text composition. Historical bad cases remain labeled as regression fixtures rather than recommended production patterns.

## Validation

- `pnpm --filter @lynx-example/text-composition run build`
- `pnpm dprint check`
- `pnpm meta-updater --test`
- `pnpm changeset status --verbose`
- `python3 .../skill-creator/scripts/quick_validate.py examples/text-composition`
- source directory to registry parity check: 24/24 cases, with no missing or extra case
- Android LynxView visual verification: 24 case screenshots, including dynamic state checks for cases 14 and 18
