### PR TITLE
fix(text-composition): correct publishing setup

### DIFF
--- a/.changeset/text-composition-example.md
+++ b/.changeset/text-composition-example.md
@@ -1,5 +1,0 @@
----
-"@lynx-example/text-composition": minor
----
-
-Add a text-composition example with 24 independently navigable source-parity cases covering natural wrapping, inline text/image/view content, truncation, events, bidirectional text, a development guide, and a reusable coding skill.

--- a/examples/text-composition/package.json
+++ b/examples/text-composition/package.json
@@ -36,5 +36,8 @@
   },
   "engines": {
     "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary

- configure `@lynx-example/text-composition` to publish with public access
- remove the pending minor changeset now that version `0.1.0` has been published manually

## Why

The package was manually published as `0.1.0`. Keeping the original changeset would cause the next Changesets version PR to bump it again to `0.2.0`. Declaring public access in the package manifest also makes the intended access level explicit for future automated releases.

This supersedes the `@lynx-example/text-composition` version bump currently included in #407. That automated version PR should not be merged for this package after this change lands.

## Impact

This only changes release metadata and does not affect the example at runtime.

## Validation

- `pnpm meta-updater --test`
- `pnpm dprint check`
- `pnpm changeset status --verbose --since origin/main`
- `pnpm --filter @lynx-example/text-composition run build`
- `git diff --check`
