### PR TITLE
refactor: let pluginReactLynx apply the engine

### DIFF
--- a/.changeset/rsbuild-plugin-lynx-example.md
+++ b/.changeset/rsbuild-plugin-lynx-example.md
@@ -2,4 +2,4 @@
 "@lynx-example/with-rsbuild": minor
 ---
 
-Add an example that builds through the Rsbuild CLI with `pluginLynx`.
+Add an example that builds through the Rsbuild CLI.

--- a/examples/with-rsbuild/README.md
+++ b/examples/with-rsbuild/README.md
@@ -3,21 +3,20 @@
 The same app as `hello-world`, built by the Rsbuild CLI instead of the Rspeedy
 CLI.
 
-`pluginLynx` carries the Lynx build engine, so `rsbuild.config.ts` needs nothing
-beyond it and the framework plugin:
+`pluginReactLynx` applies the Lynx build engine when it is not already there, so
+this is the whole plugin list:
 
 ```
-plugins: [pluginLynx(), pluginReactLynx()]
+plugins: [pluginReactLynx()]
 ```
 
-## Canary packages
+## Canary package
 
-The engine is not in a stable release yet, so this example pins two canary
-builds: `@lynx-js/rsbuild-plugin-canary` and
-`@lynx-js/react-rsbuild-plugin-canary`. Both are needed — the released
-`@lynx-js/react-rsbuild-plugin` predates the engine and leaves JSX untransformed
-against the canary engine. The runtime, `@lynx-js/react`, stays on the released
-version. Both canary pins go back to the catalog once the engine ships.
+The engine is not in a stable release yet, so this example pins
+`@lynx-js/react-rsbuild-plugin-canary`; the released
+`@lynx-js/react-rsbuild-plugin` predates the engine and leaves JSX
+untransformed. Everything else, the React runtime included, is on its released
+version. The pin goes back to the catalog entry once the engine ships.
 
 ## Scripts
 

--- a/examples/with-rsbuild/package.json
+++ b/examples/with-rsbuild/package.json
@@ -23,7 +23,6 @@
   },
   "devDependencies": {
     "@lynx-js/react-rsbuild-plugin-canary": "0.19.1-canary-20260820-d8f80cd0",
-    "@lynx-js/rsbuild-plugin-canary": "0.0.3-canary-20260820-d8f80cd0",
     "@lynx-js/types": "catalog:",
     "@rsbuild/core": "^2.0.0",
     "@types/react": "^18.3.28",

--- a/examples/with-rsbuild/rsbuild.config.ts
+++ b/examples/with-rsbuild/rsbuild.config.ts
@@ -1,11 +1,9 @@
 import { defineConfig } from "@rsbuild/core";
 
 import { pluginReactLynx } from "@lynx-js/react-rsbuild-plugin-canary";
-import { pluginLynx } from "@lynx-js/rsbuild-plugin-canary";
 
 export default defineConfig({
   plugins: [
-    pluginLynx(),
     pluginReactLynx(),
   ],
   environments: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,13 +86,13 @@ importers:
     devDependencies:
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: 'catalog:'
-        version: 0.6.0(@lynx-js/rspeedy@0.16.4(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rspack/core@2.1.10(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.101.3))
+        version: 0.6.0(@lynx-js/rspeedy@0.16.4(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rspack/core@2.1.10(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.101.3(postcss@8.5.19)))
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
         version: 0.19.0(@lynx-js/lynx-core@0.1.4)(@lynx-js/react@0.124.0(@lynx-js/types@4.1.0)(@types/react@18.3.28))(tslib@2.8.1)
       '@lynx-js/rspeedy':
         specifier: 'catalog:'
-        version: 0.16.4(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rspack/core@2.1.10(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.101.3)
+        version: 0.16.4(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rspack/core@2.1.10(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.101.3(postcss@8.5.19))
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 4.1.0
@@ -1907,10 +1907,7 @@ importers:
     devDependencies:
       '@lynx-js/react-rsbuild-plugin-canary':
         specifier: 0.19.1-canary-20260820-d8f80cd0
-        version: 0.19.1-canary-20260820-d8f80cd0(@lynx-js/lynx-core@0.1.4)(@lynx-js/react@0.124.0(@lynx-js/types@4.1.0)(@types/react@18.3.28))(@rsbuild/core@2.1.6(core-js@3.47.0))(tslib@2.8.1)(webpack@5.101.3(postcss@8.5.19))
-      '@lynx-js/rsbuild-plugin-canary':
-        specifier: 0.0.3-canary-20260820-d8f80cd0
-        version: 0.0.3-canary-20260820-d8f80cd0(@rsbuild/core@2.1.6(core-js@3.47.0))(webpack@5.101.3(postcss@8.5.19))
+        version: 0.19.1-canary-20260820-d8f80cd0(@lynx-js/lynx-core@0.1.4)(@lynx-js/react@0.124.0(@lynx-js/types@4.1.0)(@types/react@18.3.28))(@rsbuild/core@2.1.6(core-js@3.47.0))(tslib@2.8.1)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 4.1.0
@@ -9987,13 +9984,13 @@ snapshots:
     dependencies:
       '@lynx-js/react-webpack-plugin': 0.11.0(@lynx-js/react@0.124.0(@lynx-js/types@4.1.0)(@types/react@18.3.28))(@lynx-js/template-webpack-plugin@0.15.1(tslib@2.8.1))
 
-  '@lynx-js/react-rsbuild-plugin-canary@0.19.1-canary-20260820-d8f80cd0(@lynx-js/lynx-core@0.1.4)(@lynx-js/react@0.124.0(@lynx-js/types@4.1.0)(@types/react@18.3.28))(@rsbuild/core@2.1.6(core-js@3.47.0))(tslib@2.8.1)(webpack@5.101.3(postcss@8.5.19))':
+  '@lynx-js/react-rsbuild-plugin-canary@0.19.1-canary-20260820-d8f80cd0(@lynx-js/lynx-core@0.1.4)(@lynx-js/react@0.124.0(@lynx-js/types@4.1.0)(@types/react@18.3.28))(@rsbuild/core@2.1.6(core-js@3.47.0))(tslib@2.8.1)':
     dependencies:
       '@lynx-js/css-extract-webpack-plugin': '@lynx-js/css-extract-webpack-plugin-canary@0.10.1(@lynx-js/template-webpack-plugin-canary@0.15.2-canary-20260820-d8f80cd0(@lynx-js/lynx-core@0.1.4)(tslib@2.8.1))'
       '@lynx-js/react-alias-rsbuild-plugin': '@lynx-js/react-alias-rsbuild-plugin-canary@0.19.1-canary-20260820-d8f80cd0'
       '@lynx-js/react-refresh-webpack-plugin': '@lynx-js/react-refresh-webpack-plugin-canary@0.4.2(@lynx-js/react-webpack-plugin-canary@0.11.1-canary-20260820-d8f80cd0(@lynx-js/react@0.124.0(@lynx-js/types@4.1.0)(@types/react@18.3.28))(@lynx-js/template-webpack-plugin-canary@0.15.2-canary-20260820-d8f80cd0(@lynx-js/lynx-core@0.1.4)(tslib@2.8.1)))'
       '@lynx-js/react-webpack-plugin': '@lynx-js/react-webpack-plugin-canary@0.11.1-canary-20260820-d8f80cd0(@lynx-js/react@0.124.0(@lynx-js/types@4.1.0)(@types/react@18.3.28))(@lynx-js/template-webpack-plugin-canary@0.15.2-canary-20260820-d8f80cd0(@lynx-js/lynx-core@0.1.4)(tslib@2.8.1))'
-      '@lynx-js/rsbuild-plugin': '@lynx-js/rsbuild-plugin-canary@0.0.3-canary-20260820-d8f80cd0(@rsbuild/core@2.1.6(core-js@3.47.0))(webpack@5.101.3(postcss@8.5.19))'
+      '@lynx-js/rsbuild-plugin': '@lynx-js/rsbuild-plugin-canary@0.0.3-canary-20260820-d8f80cd0(@rsbuild/core@2.1.6(core-js@3.47.0))'
       '@lynx-js/runtime-wrapper-webpack-plugin': '@lynx-js/runtime-wrapper-webpack-plugin-canary@0.2.3'
       '@lynx-js/template-webpack-plugin': '@lynx-js/template-webpack-plugin-canary@0.15.2-canary-20260820-d8f80cd0(@lynx-js/lynx-core@0.1.4)(tslib@2.8.1)'
       '@lynx-js/use-sync-external-store': '@lynx-js/use-sync-external-store-canary@1.5.0(@lynx-js/react@0.124.0(@lynx-js/types@4.1.0)(@types/react@18.3.28))'
@@ -10067,7 +10064,7 @@ snapshots:
     optionalDependencies:
       '@lynx-js/types': 4.1.0
 
-  '@lynx-js/rsbuild-plugin-canary@0.0.3-canary-20260820-d8f80cd0(@rsbuild/core@2.1.6(core-js@3.47.0))(webpack@5.101.3(postcss@8.5.19))':
+  '@lynx-js/rsbuild-plugin-canary@0.0.3-canary-20260820-d8f80cd0(@rsbuild/core@2.1.6(core-js@3.47.0))':
     dependencies:
       '@lynx-js/cache-events-webpack-plugin': '@lynx-js/cache-events-webpack-plugin-canary@0.2.0'
       '@lynx-js/chunk-loading-webpack-plugin': '@lynx-js/chunk-loading-webpack-plugin-canary@0.4.1'
@@ -10076,7 +10073,7 @@ snapshots:
       '@lynx-js/webpack-dev-transport': '@lynx-js/webpack-dev-transport-canary@0.4.0'
       '@lynx-js/websocket': '@lynx-js/websocket-canary@0.0.4'
       '@rsbuild/core': 2.1.6(core-js@3.47.0)
-      '@rsbuild/plugin-css-minimizer': 2.0.1(@rsbuild/core@2.1.6(core-js@3.47.0))(webpack@5.101.3(postcss@8.5.19))
+      '@rsbuild/plugin-css-minimizer': 2.0.1(@rsbuild/core@2.1.6(core-js@3.47.0))
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/css'
@@ -11569,9 +11566,9 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-css-minimizer@2.0.1(@rsbuild/core@2.1.6(core-js@3.47.0))(webpack@5.101.3(postcss@8.5.19))':
+  '@rsbuild/plugin-css-minimizer@2.0.1(@rsbuild/core@2.1.6(core-js@3.47.0))':
     dependencies:
-      css-minimizer-webpack-plugin: 8.0.0(webpack@5.101.3(postcss@8.5.19))
+      css-minimizer-webpack-plugin: 8.0.0(webpack@5.101.3)
       reduce-configs: 1.1.2
     optionalDependencies:
       '@rsbuild/core': 2.1.6(core-js@3.47.0)


### PR DESCRIPTION
Follow-up to #413, which landed with `pluginLynx()` written out:

```diff
-    pluginLynx(),
     pluginReactLynx(),
```

`pluginReactLynx` applies the Lynx build engine when it is not already there, so naming it is redundant — the example now shows the whole plugin list as `[pluginReactLynx()]`, which is what a user actually writes. `@lynx-js/rsbuild-plugin-canary` goes with it; nobody needs to depend on the engine package directly.

Verified locally: `pnpm build` emits the same `dist/index.lynx.bundle` (491.7 kB) as before, and `pnpm dprint check`, `pnpm meta-updater --test` and `pnpm changeset status` all pass.