### PR TITLE
fix(react-apis): clarify thread macros preview

### DIFF
--- a/.changeset/calm-cats-switch.md
+++ b/.changeset/calm-cats-switch.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/react-apis": patch
+---
+
+Make the thread macros example text self-contained and allow switching between simulated main- and background-thread render results.

--- a/examples/react-apis/src/thread-macros/App.tsx
+++ b/examples/react-apis/src/thread-macros/App.tsx
@@ -7,6 +7,7 @@ function fetchProfile() {
 
 export function App() {
   const [count, setCount] = useState(0);
+  const [isMainThreadRender, setIsMainThreadRender] = useState(__MAIN_THREAD__);
 
   useEffect(() => {
     fetchProfile();
@@ -15,14 +16,18 @@ export function App() {
   function handleTap() {
     "background only";
     setCount(count + 1);
+    setIsMainThreadRender(!isMainThreadRender);
   }
 
   return (
     <view className="container">
       <view className="card" bindtap={handleTap}>
-        <text>ReactLynx</text>
-        <text>{count}</text>
-        {__MAIN_THREAD__ ? <text>main</text> : <text>background</text>}
+        <text className="cardText title">ReactLynx</text>
+        <text className="cardText">{count}</text>
+        <text className="cardText">
+          {isMainThreadRender ? "MT render" : "BT render"}
+        </text>
+        <text className="cardText hint">Tap to simulate MT / BT</text>
       </view>
     </view>
   );

--- a/examples/react-apis/src/thread-macros/index.css
+++ b/examples/react-apis/src/thread-macros/index.css
@@ -18,3 +18,18 @@
   flex-direction: column;
   gap: 8px;
 }
+
+.cardText {
+  color: #111827;
+  font-size: 16px;
+  line-height: 22px;
+}
+
+.title {
+  font-weight: 600;
+}
+
+.hint {
+  color: #64748b;
+  font-size: 13px;
+}


### PR DESCRIPTION
## Summary

- explicitly style all text in the thread-macros card so host CSS cannot make it invisible
- seed a small stateful MT/BT render simulation from `__MAIN_THREAD__`
- add a patch changeset for `@lynx-example/react-apis@0.1.5`

## Validation

- ReactLynx best-practices scan: 0 issues
- `pnpm dprint check ...`
- `pnpm meta-updater --test`
- `pnpm changeset status --verbose`
- `pnpm --filter @lynx-example/react-apis run build` (Lynx + Web)