### PR TITLE
fix(react-apis): align thread macros example with first-frame blog post

### DIFF
--- a/.changeset/align-thread-macros-blog.md
+++ b/.changeset/align-thread-macros-blog.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/react-apis": patch
+---
+
+Align thread macros example with the ReactLynx first-frame deep dive blog post.

--- a/examples/react-apis/src/thread-macros/App.tsx
+++ b/examples/react-apis/src/thread-macros/App.tsx
@@ -21,7 +21,7 @@ export function App({ initialCount = 0 }: { initialCount?: number }) {
     <view className="card" bindtap={handleTap}>
       <text className="cardText title">ReactLynx</text>
       <text className="cardText">{count}</text>
-      {/* 仅示例使用。实际代码应让主线程和后台线程结构一致。 */}
+      {/* For demonstration only. In practice, keep the structure identical across both threads. */}
       {__MAIN_THREAD__ ? <text className="cardText">main</text> : <text className="cardText">background</text>}
     </view>
   );

--- a/examples/react-apis/src/thread-macros/App.tsx
+++ b/examples/react-apis/src/thread-macros/App.tsx
@@ -5,9 +5,8 @@ function fetchProfile() {
   console.log("fetchProfile");
 }
 
-export function App() {
-  const [count, setCount] = useState(0);
-  const [isMainThreadRender, setIsMainThreadRender] = useState(__MAIN_THREAD__);
+export function App({ initialCount = 0 }: { initialCount?: number }) {
+  const [count, setCount] = useState(initialCount);
 
   useEffect(() => {
     fetchProfile();
@@ -16,19 +15,16 @@ export function App() {
   function handleTap() {
     "background only";
     setCount(count + 1);
-    setIsMainThreadRender(!isMainThreadRender);
   }
 
   return (
-    <view className="container">
-      <view className="card" bindtap={handleTap}>
-        <text className="cardText title">ReactLynx</text>
-        <text className="cardText">{count}</text>
-        <text className="cardText">
-          {isMainThreadRender ? "MT render" : "BT render"}
-        </text>
-        <text className="cardText hint">Tap to simulate MT / BT</text>
-      </view>
+    <view className="card" bindtap={handleTap}>
+      <text className="cardText title">ReactLynx</text>
+      <text className="cardText">{count}</text>
+      {/* 仅示例使用。实际代码应让主线程和后台线程结构一致。 */}
+      {__MAIN_THREAD__ ? <text className="cardText">main</text> : <text className="cardText">background</text>}
     </view>
   );
 }
+
+export default App;

--- a/examples/react-apis/src/thread-macros/index.css
+++ b/examples/react-apis/src/thread-macros/index.css
@@ -1,12 +1,11 @@
-.container {
-  width: 100%;
-  height: 100%;
+page {
+  min-height: 100vh;
+  background-color: #f5f5f5;
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-direction: column;
-  gap: 16px;
-  background-color: #f5f5f5;
+  padding: 24px;
+  box-sizing: border-box;
 }
 
 .card {
@@ -27,9 +26,4 @@
 
 .title {
   font-weight: 600;
-}
-
-.hint {
-  color: #64748b;
-  font-size: 13px;
 }


### PR DESCRIPTION
## Summary

Align the `thread-macros` example in `examples/react-apis` with the original teaching example in the ReactLynx first-frame deep dive blog post:
- Restore `{__MAIN_THREAD__ ? <text className="cardText">main</text> : <text className="cardText">background</text>}` branch directly in the JSX tree so it matches the compile-time `$1` branch pruning and hydration takeover explanations in the article.
- Use `page` styling in `index.css` to center the `.card` so that `<view className="card">` remains the root view of `App`, matching the `-1 view.card` ID mapping in the blog.
- Restore `App({ initialCount = 0 })` prop and `useState(initialCount)`.
- Include a patch changeset for `@lynx-example/react-apis`.

## Validation

- `pnpm dprint check ...`
- `pnpm changeset status --verbose`
- `pnpm --filter @lynx-example/react-apis run build` (Lynx + Web)