### PR TITLE
fix(react-apis): isolate thread macros preview state

### DIFF
--- a/.changeset/interactive-thread-preview.md
+++ b/.changeset/interactive-thread-preview.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/react-apis": patch
+---
+
+Keep the blog's thread macros component unchanged while adding an interactive phase preview around it.

--- a/examples/react-apis/src/thread-macros/ThreadMacrosDemo.tsx
+++ b/examples/react-apis/src/thread-macros/ThreadMacrosDemo.tsx
@@ -1,0 +1,47 @@
+import { useState } from "@lynx-js/react";
+import { App } from "./App.jsx";
+
+type PreviewPhase = "first-frame" | "background";
+
+function FirstFrameSnapshot() {
+  return (
+    <view className="card">
+      <text className="cardText title">ReactLynx</text>
+      <text className="cardText">0</text>
+      <text className="cardText">main</text>
+    </view>
+  );
+}
+
+export function ThreadMacrosDemo() {
+  const runtimePhase: PreviewPhase = __MAIN_THREAD__ ? "first-frame" : "background";
+  const [previewPhase, setPreviewPhase] = useState<PreviewPhase>(runtimePhase);
+  const isLiveResult = previewPhase === runtimePhase;
+
+  return (
+    <view className="threadMacrosDemo">
+      <view className="phaseSelector">
+        <view
+          className="phaseButton"
+          bindtap={() => setPreviewPhase("first-frame")}
+        >
+          <text className="phaseButtonText">First-frame result</text>
+        </view>
+        <view
+          className="phaseButton"
+          bindtap={() => setPreviewPhase("background")}
+        >
+          <text className="phaseButtonText">After background takeover</text>
+        </view>
+      </view>
+
+      <text className="phaseNote">
+        {isLiveResult
+          ? "Select a result to compare the two phases."
+          : "A visual replay of the main-thread first frame."}
+      </text>
+
+      {isLiveResult ? <App /> : <FirstFrameSnapshot />}
+    </view>
+  );
+}

--- a/examples/react-apis/src/thread-macros/index.css
+++ b/examples/react-apis/src/thread-macros/index.css
@@ -8,6 +8,39 @@ page {
   box-sizing: border-box;
 }
 
+.threadMacrosDemo {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.phaseSelector {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+}
+
+.phaseButton {
+  padding: 8px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  background-color: white;
+}
+
+.phaseButtonText {
+  color: #1f2937;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.phaseNote {
+  color: #64748b;
+  font-size: 13px;
+  line-height: 18px;
+}
+
 .card {
   padding: 24px;
   background-color: white;

--- a/examples/react-apis/src/thread-macros/index.tsx
+++ b/examples/react-apis/src/thread-macros/index.tsx
@@ -1,8 +1,8 @@
 import { root } from "@lynx-js/react";
-import { App } from "./App.jsx";
+import { ThreadMacrosDemo } from "./ThreadMacrosDemo.jsx";
 import "./index.css";
 
-root.render(<App />);
+root.render(<ThreadMacrosDemo />);
 
 if (import.meta.webpackHot) {
   import.meta.webpackHot.accept();


### PR DESCRIPTION
## Summary

The thread macros example is shared by the ReactLynx first-frame blog and the built-in macros API reference. An earlier interactive version put simulated phase state inside `App`, which obscured the compile-time `__MAIN_THREAD__` branch. Restoring `App` fixed the source fidelity but removed deliberate controls for comparing the two rendered phases.

This change moves the interaction into a `ThreadMacrosDemo` wrapper:

- keeps `App.tsx` unchanged as the canonical, standalone macro example;
- derives the real runtime phase from `__MAIN_THREAD__` in the wrapper;
- renders the real `App` for the active phase and uses a static snapshot only when replaying the main-thread first frame after background takeover;
- keeps the wrapper initial output identical across both builds, so the visible takeover difference remains owned by `App`.

The first-frame control is intentionally a visual replay after background takeover; it does not attempt to rewind hydration.

## Review focus

Please check the ownership boundary between the reusable `App` example and the preview-only shell, especially that the shell does not introduce additional initial main/background output differences.