### PR TITLE
fix(react-apis): balance thread preview controls

### DIFF
--- a/.changeset/tidy-thread-preview-layout.md
+++ b/.changeset/tidy-thread-preview-layout.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/react-apis": patch
+---
+
+Balance the thread macros phase controls at narrow preview widths.

--- a/examples/react-apis/src/thread-macros/ThreadMacrosDemo.tsx
+++ b/examples/react-apis/src/thread-macros/ThreadMacrosDemo.tsx
@@ -31,7 +31,7 @@ export function ThreadMacrosDemo() {
           className="phaseButton"
           bindtap={() => setPreviewPhase("background")}
         >
-          <text className="phaseButtonText">After background takeover</text>
+          <text className="phaseButtonText">Background takeover</text>
         </view>
       </view>
 

--- a/examples/react-apis/src/thread-macros/index.css
+++ b/examples/react-apis/src/thread-macros/index.css
@@ -17,28 +17,42 @@ page {
 }
 
 .phaseSelector {
+  width: 100%;
+  max-width: 320px;
   display: flex;
   flex-direction: row;
   gap: 8px;
 }
 
 .phaseButton {
-  padding: 8px 12px;
+  flex: 1;
+  min-height: 56px;
+  padding: 10px 8px;
   border: 1px solid #d1d5db;
   border-radius: 8px;
   background-color: white;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .phaseButtonText {
+  width: 100%;
   color: #1f2937;
   font-size: 13px;
+  font-weight: 500;
   line-height: 18px;
+  text-align: center;
 }
 
 .phaseNote {
+  width: 100%;
+  max-width: 320px;
   color: #64748b;
   font-size: 13px;
   line-height: 18px;
+  text-align: center;
 }
 
 .card {


### PR DESCRIPTION
## Summary

At narrow preview widths, the two thread-phase controls sized themselves from their labels. The longer background label produced uneven columns and asymmetric line wrapping, while the left-aligned note pulled the layout away from the centered example card.

This change gives the selector a shared maximum width, distributes both controls equally, and centers their labels within a common minimum height. It also shortens the second label to “Background takeover” and aligns the explanatory note to the same centered width.

Both controls intentionally remain visually neutral across phases. The wrapper therefore keeps identical initial presentation outside `App`, preserving the existing ownership of the visible main/background takeover difference. Runtime phase selection and the reusable `App` example are unchanged.

## Review focus

Please check the two-line wrapping and visual balance at narrow Go preview widths, along with the invariant that this remains a presentation-only change.