### PR TITLE
chore: sort package.json files with dprint

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -8,6 +8,8 @@
       ".vscode/settings.json",
     ],
   },
+  "sortPackageJson": {
+  },
   "markdown": {
   },
   "toml": {
@@ -25,6 +27,7 @@
     "**/routeTree.gen.ts",
   ],
   "plugins": [
+    "https://github.com/colinaaa/dprint-plugin-sort-package-json/releases/download/0.2.1/plugin.wasm",
     "https://plugins.dprint.dev/typescript-0.95.15.wasm",
     "https://plugins.dprint.dev/json-0.21.3.wasm",
     "https://plugins.dprint.dev/markdown-0.21.1.wasm",

--- a/.meta-updater/main.mjs
+++ b/.meta-updater/main.mjs
@@ -2,7 +2,6 @@
 
 import { createUpdateOptions } from "@pnpm/meta-updater";
 import path from "node:path";
-import { sortPackageJson } from "sort-package-json";
 
 const REPOSITORY_TYPE = "git";
 const REPOSITORY_URL = "git+https://github.com/lynx-family/lynx-examples.git";
@@ -54,7 +53,7 @@ const normalizeRepository = (repository, dirOrOptions, workspaceDir) => {
 export default (workspaceDir) => {
   return createUpdateOptions({
     "package.json": (manifest, options) => {
-      return sortPackageJson({
+      return {
         ...manifest,
         author: "Lynx Authors",
         repository: normalizeRepository(
@@ -62,7 +61,7 @@ export default (workspaceDir) => {
           options,
           workspaceDir,
         ),
-      });
+      };
     },
   });
 };

--- a/api/css/package.json
+++ b/api/css/package.json
@@ -2,14 +2,13 @@
   "name": "@lynx-example/css-api",
   "version": "0.10.4",
   "description": "CSS properties API demo",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "api/css"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
@@ -17,6 +16,7 @@
     "lynx.web.config.mjs",
     "lynx.config.mjs"
   ],
+  "type": "module",
   "scripts": {
     "build": "node ./scripts/build.mjs",
     "dev": "rspeedy dev",

--- a/examples/7guis/package.json
+++ b/examples/7guis/package.json
@@ -3,14 +3,13 @@
   "version": "0.2.4",
   "private": false,
   "description": "7 GUIs benchmark — Counter, Temperature Converter, Flight Booker, Timer, CRUD, Circle Drawer, Cells",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/7guis"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist",
     "src",
@@ -18,6 +17,7 @@
     "tsconfig.json",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev"

--- a/examples/BankCards/package.json
+++ b/examples/BankCards/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/bankcards",
   "version": "0.6.9",
   "description": "An demo implements bankcards",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/BankCards"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/Gallery/package.json
+++ b/examples/Gallery/package.json
@@ -2,14 +2,13 @@
   "name": "@lynx-example/gallery",
   "version": "0.6.12",
   "description": "An example shows how to build a picture gallery and master Lynx better",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/Gallery"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "resource/",
@@ -17,6 +16,7 @@
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/a2ui/package.json
+++ b/examples/a2ui/package.json
@@ -2,19 +2,22 @@
   "name": "@lynx-example/a2ui",
   "version": "0.1.3",
   "description": "An example shows how to use a2ui in Lynx",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/a2ui"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "npm run catalog && rspeedy build",
     "catalog": "genui-cli a2ui generate catalog --source src/catalog --out-dir src/catalog",
@@ -38,8 +41,5 @@
   },
   "engines": {
     "node": ">=22"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/examples/accessibility/package.json
+++ b/examples/accessibility/package.json
@@ -2,19 +2,19 @@
   "name": "@lynx-example/accessibility",
   "version": "0.6.9",
   "description": "An example shows how to make App accessible in ReactLynx",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/accessibility"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/action-sheet/package.json
+++ b/examples/action-sheet/package.json
@@ -2,19 +2,19 @@
   "name": "@lynx-example/action-sheet",
   "version": "0.6.9",
   "description": "An example shows how to build an ActionSheet in Lynx",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/action-sheet"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/animation/package.json
+++ b/examples/animation/package.json
@@ -2,14 +2,13 @@
   "name": "@lynx-example/animation",
   "version": "0.6.11",
   "description": "An example shows how to use Lynx CSS Animation",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/animation"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
@@ -17,6 +16,7 @@
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build && rspeedy build --config lynx.web.config.mjs",
     "dev": "rspeedy dev",

--- a/examples/animax/package.json
+++ b/examples/animax/package.json
@@ -2,19 +2,22 @@
   "name": "@lynx-example/animax",
   "version": "0.1.3",
   "description": "Examples showing how to use `<animax-view>` in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/animax"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts"
   ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",
@@ -33,8 +36,5 @@
   },
   "engines": {
     "node": ">=18"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/examples/blur-view/package.json
+++ b/examples/blur-view/package.json
@@ -2,19 +2,19 @@
   "name": "@lynx-example/blur-view",
   "version": "0.1.4",
   "description": "An example shows how to use `<blur-view>` in Lynx",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/blur-view"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/composing-elements/package.json
+++ b/examples/composing-elements/package.json
@@ -2,19 +2,19 @@
   "name": "@lynx-example/composing-elements",
   "version": "0.6.9",
   "description": "An example shows how to composing elements in ReactLynx",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/composing-elements"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/css-global/package.json
+++ b/examples/css-global/package.json
@@ -2,20 +2,23 @@
   "name": "@lynx-example/css-global",
   "version": "0.1.2",
   "description": "An example shows how to use global CSS in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/css-global"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",
@@ -34,8 +37,5 @@
   },
   "engines": {
     "node": ">=18"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/examples/css-modules/package.json
+++ b/examples/css-modules/package.json
@@ -2,20 +2,23 @@
   "name": "@lynx-example/css-modules",
   "version": "0.1.2",
   "description": "An example shows how to use CSS Modules in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/css-modules"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",
@@ -35,8 +38,5 @@
   },
   "engines": {
     "node": ">=18"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/examples/css-postcss/package.json
+++ b/examples/css-postcss/package.json
@@ -2,14 +2,13 @@
   "name": "@lynx-example/css-postcss",
   "version": "0.1.2",
   "description": "An example shows how to use PostCSS in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/css-postcss"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
@@ -17,6 +16,10 @@
     "postcss.config.js",
     "CHANGELOG.md"
   ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",
@@ -36,8 +39,5 @@
   },
   "engines": {
     "node": ">=18"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/examples/css-preprocessors/package.json
+++ b/examples/css-preprocessors/package.json
@@ -2,20 +2,23 @@
   "name": "@lynx-example/css-preprocessors",
   "version": "0.1.2",
   "description": "An example shows how to use Sass, Less and Stylus in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/css-preprocessors"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",
@@ -37,8 +40,5 @@
   },
   "engines": {
     "node": ">=18"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/examples/css/package.json
+++ b/examples/css/package.json
@@ -2,14 +2,13 @@
   "name": "@lynx-example/css",
   "version": "0.6.9",
   "description": "An example shows how to use different CSS properties",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/css"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "resource/",
@@ -17,6 +16,7 @@
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/design-guide/package.json
+++ b/examples/design-guide/package.json
@@ -3,24 +3,23 @@
   "version": "0.4.7",
   "description": "An example demonstrating design with Lynx capabilities",
   "keywords": [
-    "lynx",
-    "lynx-js",
-    "example",
+    "animation",
     "design",
     "design-engineering",
     "design-guide",
-    "ui",
-    "animation",
-    "effects"
+    "effects",
+    "example",
+    "lynx",
+    "lynx-js",
+    "ui"
   ],
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/design-guide"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
@@ -28,6 +27,7 @@
     "CHANGELOG.md",
     "lynx.config.mjs"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/desktop/package.json
+++ b/examples/desktop/package.json
@@ -2,19 +2,19 @@
   "name": "@lynx-example/desktop",
   "version": "0.2.4",
   "description": "Desktop-oriented cursor demos for Lynx",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/desktop"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/element-manipulation/package.json
+++ b/examples/element-manipulation/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/element-manipulation",
   "version": "0.6.10",
   "description": "Lynx element manipulation demo",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/element-manipulation"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/event/package.json
+++ b/examples/event/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/event",
   "version": "0.6.10",
   "description": "An example shows how to use Lynx Event",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/event"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/external-bundle/package.json
+++ b/examples/external-bundle/package.json
@@ -2,14 +2,13 @@
   "name": "@lynx-example/external-bundle",
   "version": "0.0.9",
   "description": "Using external bundle in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/external-bundle"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
@@ -18,6 +17,7 @@
     "README.md",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "pnpm build:bundle && rspeedy build",
     "build:bundle": "rm -rf dist-external-bundle && pnpm run --stream '/^build:bundle:.*/'",

--- a/examples/fetch/package.json
+++ b/examples/fetch/package.json
@@ -2,13 +2,12 @@
   "name": "@lynx-example/fetch",
   "version": "0.6.9",
   "description": "An example shows how fetch API work in ReactLynx",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/fetch"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "index.scss",
@@ -16,6 +15,7 @@
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/frame/package.json
+++ b/examples/frame/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/frame",
   "version": "0.1.6",
   "description": "An example shows how to use `<frame>` in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/frame"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -1,19 +1,19 @@
 {
   "name": "@lynx-example/hello-world",
   "version": "0.6.12",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/hello-world"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist",
     "src",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/i18n/package.json
+++ b/examples/i18n/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@lynx-example/i18n",
   "version": "0.5.9",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/i18n"
   },
-  "author": "Lynx Authors",
   "type": "module",
   "scripts": {
     "build": "rspeedy build",

--- a/examples/ifr/package.json
+++ b/examples/ifr/package.json
@@ -2,19 +2,19 @@
   "name": "@lynx-example/ifr",
   "version": "0.5.9",
   "description": "An example about Instant First-Frame Rendering (IFR) in Lynx",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/ifr"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/image/package.json
+++ b/examples/image/package.json
@@ -2,19 +2,19 @@
   "name": "@lynx-example/image",
   "version": "0.6.9",
   "description": "An example shows how to use different kinds of images in Lynx",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/image"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/input/package.json
+++ b/examples/input/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/input",
   "version": "0.6.10",
   "description": "An example shows how to use input in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/input"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build && rspeedy build --config lynx.web.config.mjs",
     "dev": "rspeedy dev",

--- a/examples/layout/package.json
+++ b/examples/layout/package.json
@@ -2,14 +2,13 @@
   "name": "@lynx-example/layout",
   "version": "0.6.9",
   "description": "Examples of the layout related styling",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/layout"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
@@ -17,6 +16,7 @@
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build && rspeedy build --config lynx.web.config.mjs",
     "dev": "rspeedy dev",

--- a/examples/lazy-bundle/package.json
+++ b/examples/lazy-bundle/package.json
@@ -1,13 +1,12 @@
 {
   "name": "@lynx-example/lazy-bundle",
   "version": "0.6.10",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/lazy-bundle"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "dist-fetchbundle/",
@@ -18,6 +17,7 @@
     "demo-config.js",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "pnpm run build:querycomponent && pnpm run build:fetchbundle",
     "build:app": "rspeedy build",

--- a/examples/list/package.json
+++ b/examples/list/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/list",
   "version": "0.6.10",
   "description": "An example shows how to use list in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/list"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/local-storage/package.json
+++ b/examples/local-storage/package.json
@@ -1,19 +1,19 @@
 {
   "name": "@lynx-example/local-storage",
   "version": "0.6.10",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/local-storage"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "check": "biome check --write",

--- a/examples/lynx-api/package.json
+++ b/examples/lynx-api/package.json
@@ -1,13 +1,12 @@
 {
   "name": "@lynx-example/lynx-api",
   "version": "0.1.11",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/lynx-api"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
@@ -15,6 +14,7 @@
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "check": "biome check --write",

--- a/examples/lynx-ui-gallery/package.json
+++ b/examples/lynx-ui-gallery/package.json
@@ -2,19 +2,22 @@
   "name": "@lynx-example/lynx-ui-gallery",
   "version": "0.2.3",
   "description": "A Kitchen Sink gallery showcasing all lynx-ui components",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/lynx-ui-gallery"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",
@@ -36,8 +39,5 @@
   },
   "engines": {
     "node": ">=22"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/examples/main-thread/package.json
+++ b/examples/main-thread/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/main-thread",
   "version": "0.4.11",
   "description": "Lynx main thread demo",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/main-thread"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/markdown/package.json
+++ b/examples/markdown/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/markdown",
   "version": "0.1.3",
   "description": "An example shows how to use `<markdown>` in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/markdown"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/motion/package.json
+++ b/examples/motion/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/motion",
   "version": "0.2.5",
   "description": "Examples for @lynx-js/motion and @lynx-js/motion/mini",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/motion"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/native-element/package.json
+++ b/examples/native-element/package.json
@@ -2,19 +2,19 @@
   "name": "@lynx-example/native-element",
   "version": "0.6.11",
   "description": "An example about using native element in Lynx",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/native-element"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/networking/package.json
+++ b/examples/networking/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/networking",
   "version": "0.4.11",
   "description": "An example shows Lynx networking abilities",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/networking"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/openui/package.json
+++ b/examples/openui/package.json
@@ -2,14 +2,13 @@
   "name": "@lynx-example/openui",
   "version": "0.1.4",
   "description": "An example shows how to render streaming OpenUI responses in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/openui"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
@@ -17,6 +16,10 @@
     "tsconfig.json",
     "CHANGELOG.md"
   ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",
@@ -39,8 +42,5 @@
   },
   "engines": {
     "node": ">=22"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/examples/overlay/package.json
+++ b/examples/overlay/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/overlay",
   "version": "0.6.11",
   "description": "An example shows how to use `<overlay>` in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/overlay"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/page/package.json
+++ b/examples/page/package.json
@@ -2,19 +2,19 @@
   "name": "@lynx-example/page",
   "version": "0.6.9",
   "description": "An example shows how to use page in Lynx",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/page"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/performance-api/package.json
+++ b/examples/performance-api/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/performance-api",
   "version": "0.7.4",
   "description": "Examples of Performance API",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/performance-api"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/react-apis/package.json
+++ b/examples/react-apis/package.json
@@ -2,19 +2,22 @@
   "name": "@lynx-example/react-apis",
   "version": "0.1.7",
   "description": "Examples for APIs exported by ReactLynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/react-apis"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts"
   ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",
@@ -33,8 +36,5 @@
   },
   "engines": {
     "node": ">=22"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/examples/react-devtool/package.json
+++ b/examples/react-devtool/package.json
@@ -2,19 +2,22 @@
   "name": "@lynx-example/react-devtool",
   "version": "0.2.5",
   "description": "lynx-ui-gallery with @lynx-js/preact-devtools enabled",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/react-devtool"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "REACT_DEVTOOL=true rspeedy build",
     "dev": "rspeedy dev",
@@ -38,8 +41,5 @@
   },
   "engines": {
     "node": ">=22"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/examples/react-lifecycle/package.json
+++ b/examples/react-lifecycle/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/react-lifecycle",
   "version": "0.5.10",
   "description": "ReactLynx lifecycle demo",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/react-lifecycle"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/refresh/package.json
+++ b/examples/refresh/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/refresh",
   "version": "0.6.13",
   "description": "An example shows how to use `<refresh>` in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/refresh"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/scroll-coordinator/package.json
+++ b/examples/scroll-coordinator/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/scroll-coordinator",
   "version": "0.6.17",
   "description": "An example shows how to use `<scroll-coordinator>` in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/scroll-coordinator"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/scroll-view/package.json
+++ b/examples/scroll-view/package.json
@@ -2,19 +2,19 @@
   "name": "@lynx-example/scroll-view",
   "version": "0.6.9",
   "description": "An example shows how to use scrollable container",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/scroll-view"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/svg/package.json
+++ b/examples/svg/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/svg",
   "version": "0.6.13",
   "description": "An example shows how to use `<svg>` in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/svg"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/swiper/package.json
+++ b/examples/swiper/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/swiper",
   "version": "0.5.10",
   "description": "An example shows how to use main thread script for interaction",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/swiper"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/tailwindcss/package.json
+++ b/examples/tailwindcss/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@lynx-example/tailwindcss",
   "version": "0.5.4",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/tailwindcss"
   },
-  "author": "Lynx Authors",
   "type": "module",
   "scripts": {
     "build": "rspeedy build",

--- a/examples/tanstack-router/package.json
+++ b/examples/tanstack-router/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/tanstack-router",
   "version": "0.6.12",
   "description": "An example shows how to use TanStack Router in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/tanstack-router"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/text-composition/package.json
+++ b/examples/text-composition/package.json
@@ -2,14 +2,13 @@
   "name": "@lynx-example/text-composition",
   "version": "0.2.1",
   "description": "A Lynx text-composition example covering natural wrapping, inline text, images, views, and truncation",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/text-composition"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
@@ -18,6 +17,10 @@
     "CHANGELOG.md",
     "SKILL.md"
   ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",
@@ -36,8 +39,5 @@
   },
   "engines": {
     "node": ">=22"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/examples/text/package.json
+++ b/examples/text/package.json
@@ -2,14 +2,13 @@
   "name": "@lynx-example/text",
   "version": "0.6.10",
   "description": "An example shows how to use text and inline-text in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/text"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
@@ -17,6 +16,7 @@
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/textarea/package.json
+++ b/examples/textarea/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/textarea",
   "version": "0.6.11",
   "description": "An example shows how to use textarea in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/textarea"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/title-bar-view/package.json
+++ b/examples/title-bar-view/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/title-bar-view",
   "version": "0.6.15",
   "description": "An example shows how to use `<title-bar-view>` in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/title-bar-view"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/vanilla/package.json
+++ b/examples/vanilla/package.json
@@ -2,19 +2,22 @@
   "name": "@lynx-example/vanilla",
   "version": "0.1.6",
   "description": "An example of building Lynx apps with Element PAPI",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/vanilla"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist",
     "src",
     "lynx.config.ts"
   ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",
@@ -35,8 +38,5 @@
   },
   "engines": {
     "node": ">=18"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/examples/video/package.json
+++ b/examples/video/package.json
@@ -2,19 +2,22 @@
   "name": "@lynx-example/video",
   "version": "0.2.3",
   "description": "An example shows how to use `<video>` in Lynx",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/video"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",
@@ -33,8 +36,5 @@
   },
   "engines": {
     "node": ">=18"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/examples/view/package.json
+++ b/examples/view/package.json
@@ -2,19 +2,19 @@
   "name": "@lynx-example/view",
   "version": "0.6.9",
   "description": "An example shows how to use view in Lynx",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/view"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/viewpager/package.json
+++ b/examples/viewpager/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/viewpager",
   "version": "0.6.16",
   "description": "An example shows how to use `<viewpager>` in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/viewpager"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/web-platform/package.json
+++ b/examples/web-platform/package.json
@@ -3,13 +3,13 @@
   "version": "0.0.0",
   "private": true,
   "description": "An example shows how to use Lynx Web Platform",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/web-platform"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
   "scripts": {
     "build": "pnpm --filter lynx-project run build",
     "dev": "pnpm --filter react-container run dev"

--- a/examples/web-platform/packages/lynx-project/package.json
+++ b/examples/web-platform/packages/lynx-project/package.json
@@ -2,12 +2,12 @@
   "name": "@lynx-example/lynx-project",
   "version": "0.0.0",
   "private": true,
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/web-platform/packages/lynx-project"
   },
-  "author": "Lynx Authors",
   "type": "module",
   "scripts": {
     "build": "rspeedy build",

--- a/examples/web-platform/packages/react-container/package.json
+++ b/examples/web-platform/packages/react-container/package.json
@@ -2,12 +2,12 @@
   "name": "@lynx-example/react-container",
   "version": "0.0.0",
   "private": true,
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/web-platform/packages/react-container"
   },
-  "author": "Lynx Authors",
   "scripts": {
     "build": "rsbuild build",
     "dev": "rsbuild dev --open",

--- a/examples/webassembly/package.json
+++ b/examples/webassembly/package.json
@@ -2,19 +2,22 @@
   "name": "@lynx-example/webassembly",
   "version": "0.2.3",
   "description": "An example shows how to run WebAssembly in Lynx",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/webassembly"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist",
     "src",
     "lynx.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",
@@ -33,8 +36,5 @@
   },
   "engines": {
     "node": ">=18"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/examples/webview/package.json
+++ b/examples/webview/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/webview",
   "version": "0.1.4",
   "description": "An example shows how to use `<x-webview>` in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/webview"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/examples/with-rsbuild/package.json
+++ b/examples/with-rsbuild/package.json
@@ -1,19 +1,19 @@
 {
   "name": "@lynx-example/with-rsbuild",
   "version": "0.1.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/with-rsbuild"
   },
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist",
     "src",
     "rsbuild.config.ts",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rsbuild build",
     "dev": "rsbuild dev"

--- a/examples/with-solidjs/package.json
+++ b/examples/with-solidjs/package.json
@@ -2,14 +2,13 @@
   "name": "@lynx-example/with-solidjs",
   "version": "0.4.8",
   "description": "An example shows how to use Lynx with SolidJS",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/with-solidjs"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
@@ -17,6 +16,7 @@
     "README.md",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspack build",
     "dev": "rspack dev"

--- a/examples/with-solidjs/packages/solid/package.json
+++ b/examples/with-solidjs/packages/solid/package.json
@@ -2,12 +2,12 @@
   "name": "@lynx-js/solid",
   "version": "0.0.0",
   "private": true,
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/with-solidjs/packages/solid"
   },
-  "author": "Lynx Authors",
   "type": "module",
   "module": "./src/index.ts",
   "types": "./src/index.ts",

--- a/examples/zustand/package.json
+++ b/examples/zustand/package.json
@@ -2,20 +2,20 @@
   "name": "@lynx-example/zustand",
   "version": "0.6.9",
   "description": "An example shows how to use zustand in Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git",
     "directory": "examples/zustand"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
-  "type": "module",
   "files": [
     "dist/",
     "src/",
     "lynx.config.mjs",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",

--- a/package.json
+++ b/package.json
@@ -3,20 +3,15 @@
   "version": "0.0.0",
   "private": true,
   "description": "The examples for Lynx",
+  "license": "Apache-2.0",
+  "author": "Lynx Authors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-examples.git"
   },
-  "license": "Apache-2.0",
-  "author": "Lynx Authors",
   "scripts": {
     "build": "EXPERIMENTAL_USE_WEB_BINARY_TEMPLATE=false turbo run build",
     "prepare": "husky"
-  },
-  "nano-staged": {
-    "*.{css,scss,js,jsx,ts,tsx,mjs,cjs,json,jsonc,md}": [
-      "dprint fmt --allow-no-files --"
-    ]
   },
   "devDependencies": {
     "@changesets/cli": "^3.0.0",
@@ -25,12 +20,16 @@
     "dprint": "^0.52.0",
     "husky": "^9.1.7",
     "nano-staged": "^1.0.2",
-    "sort-package-json": "^4.0.0",
     "turbo": "^2.8.13"
   },
-  "packageManager": "pnpm@11.13.0",
+  "nano-staged": {
+    "*.{css,scss,js,jsx,ts,tsx,mjs,cjs,json,jsonc,md}": [
+      "dprint fmt --allow-no-files --"
+    ]
+  },
   "engines": {
     "node": ">=22",
     "pnpm": "11.13.0"
-  }
+  },
+  "packageManager": "pnpm@11.13.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,6 @@ importers:
       nano-staged:
         specifier: ^1.0.2
         version: 1.0.2
-      sort-package-json:
-        specifier: ^4.0.0
-        version: 4.0.0
       turbo:
         specifier: ^2.8.13
         version: 2.9.14
@@ -5706,10 +5703,6 @@ packages:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
 
-  detect-newline@4.0.1:
-    resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
@@ -6089,9 +6082,6 @@ packages:
 
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
-
-  git-hooks-list@4.1.1:
-    resolution: {integrity: sha512-cmP497iLq54AZnv4YRAEMnEyQ1eIn4tGKbmswqwmFV4GBnAqE8NLtWxxdXa++AalfgL5EBH4IxTPyquEuGY/jA==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -7831,11 +7821,6 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -7966,14 +7951,6 @@ packages:
   sort-keys@5.1.0:
     resolution: {integrity: sha512-aSbHV0DaBcr7u0PVHXzM6NbZNAtrr9sF6+Qfs9UUVG7Ll3jQ6hHi8F/xqIIcn2rvIVbr0v/2zyjSdwSV47AgLQ==}
     engines: {node: '>=12'}
-
-  sort-object-keys@2.0.1:
-    resolution: {integrity: sha512-R89fO+z3x7hiKPXX5P0qim+ge6Y60AjtlW+QQpRozrrNcR1lw9Pkpm5MLB56HoNvdcLHL4wbpq16OcvGpEDJIg==}
-
-  sort-package-json@4.0.0:
-    resolution: {integrity: sha512-6aYOlYI9AWioZ+rzu+4zKLmoFqJP0/fHDxrd7X04yqEibikY+5YVF0EYlyGn4v6X2PJY7yAUWV7oeP+i5rOm/g==}
-    engines: {node: '>=22'}
-    hasBin: true
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -13265,8 +13242,6 @@ snapshots:
 
   detect-libc@2.0.4: {}
 
-  detect-newline@4.0.1: {}
-
   didyoumean@1.2.2: {}
 
   diff@5.2.0: {}
@@ -13747,8 +13722,6 @@ snapshots:
   get-tsconfig@4.10.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  git-hooks-list@4.1.1: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -15458,8 +15431,6 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.7.4: {}
-
   semver@7.8.5: {}
 
   serialize-javascript@7.0.7: {}
@@ -15612,18 +15583,6 @@ snapshots:
   sort-keys@5.1.0:
     dependencies:
       is-plain-obj: 4.1.0
-
-  sort-object-keys@2.0.1: {}
-
-  sort-package-json@4.0.0:
-    dependencies:
-      detect-indent: 7.0.2
-      detect-newline: 4.0.1
-      git-hooks-list: 4.1.1
-      is-plain-obj: 4.1.0
-      semver: 7.7.4
-      sort-object-keys: 2.0.1
-      tinyglobby: 0.2.15
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary

- add `dprint-plugin-sort-package-json` 0.2.1 to the dprint configuration
- remove the standalone `sort-package-json` dependency and meta-updater integration
- format all workspace manifests with the dprint plugin

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm dprint check`
- `pnpm meta-updater --test`
- `git diff --check`
- semantic audit of all 71 changed manifests (only key ordering, keyword ordering, and removal of the old root dependency)

No changeset is needed because this only changes repository tooling and manifest formatting.