### PR TITLE
fix(with-rsbuild): configure the bundle filename through pluginLynx

### DIFF
--- a/.changeset/with-rsbuild-plugin-lynx-filename.md
+++ b/.changeset/with-rsbuild-plugin-lynx-filename.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/with-rsbuild": patch
+---
+
+Configure the bundle filename through `pluginLynx` instead of `output.filename`.

--- a/examples/external-bundle/turbo.json
+++ b/examples/external-bundle/turbo.json
@@ -1,12 +1,20 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": ["//"],
+  "extends": [
+    "//"
+  ],
   "tasks": {
     "build": {
-      "dependsOn": ["build:bundle"]
+      "dependsOn": [
+        "build:bundle"
+      ]
     },
     "build:bundle": {
-      "dependsOn": ["build:bundle:lodash", "build:bundle:react", "build:bundle:comp", "build:bundle:utils"],
+      "dependsOn": [
+        "build:bundle:lodash",
+        "build:bundle:comp",
+        "build:bundle:utils"
+      ],
       "outputs": []
     },
     "build:bundle:lodash": {
@@ -16,15 +24,6 @@
       ],
       "outputs": [
         "dist/lodash-es.lynx.bundle"
-      ]
-    },
-    "build:bundle:react": {
-      "inputs": [
-        "react.rslib.config.js",
-        "node_modules/@lynx-js/react/**"
-      ],
-      "outputs": [
-        "dist/react.lynx.bundle"
       ]
     },
     "build:bundle:comp": {

--- a/examples/with-rsbuild/package.json
+++ b/examples/with-rsbuild/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@lynx-js/react-rsbuild-plugin": "catalog:",
+    "@lynx-js/rsbuild-plugin": "catalog:",
     "@lynx-js/types": "catalog:",
     "@rsbuild/core": "^2.0.0",
     "@types/react": "^18.3.28",

--- a/examples/with-rsbuild/rsbuild.config.ts
+++ b/examples/with-rsbuild/rsbuild.config.ts
@@ -1,9 +1,17 @@
 import { defineConfig } from "@rsbuild/core";
 
 import { pluginReactLynx } from "@lynx-js/react-rsbuild-plugin";
+import { pluginLynx } from "@lynx-js/rsbuild-plugin";
 
 export default defineConfig({
   plugins: [
+    pluginLynx({
+      output: {
+        filename: {
+          bundle: "[name].[platform].bundle",
+        },
+      },
+    }),
     pluginReactLynx(),
   ],
   environments: {
@@ -11,6 +19,5 @@ export default defineConfig({
   },
   output: {
     dataUriLimit: Infinity,
-    filename: "[name].[platform].bundle",
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1914,6 +1914,9 @@ importers:
       '@lynx-js/react-rsbuild-plugin':
         specifier: 'catalog:'
         version: 0.20.1(@lynx-js/react@0.126.0(@lynx-js/types@4.2.1)(@types/react@18.3.28))(@lynx-js/rspeedy@0.17.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rspack/core@2.2.2(@swc/helpers@0.5.23))(core-js@3.47.0)(tslib@2.8.1)(typescript@5.9.3)(webpack@5.101.3))(@rsbuild/core@2.1.6(core-js@3.47.0))(tslib@2.8.1)(webpack@5.101.3)
+      '@lynx-js/rsbuild-plugin':
+        specifier: 'catalog:'
+        version: 0.1.1(@rsbuild/core@2.1.6(core-js@3.47.0))(tslib@2.8.1)(webpack@5.101.3)
       '@lynx-js/types':
         specifier: 'catalog:'
         version: 4.2.1


### PR DESCRIPTION
`output.filename` on a plain Rsbuild config must be a `FilenameConfig` object, so the string in `with-rsbuild` was silently ignored. The artifact only happened to look right because `[name].[platform].bundle` is also `pluginLynx`'s default — nothing was actually reading the setting, and `tsc --noEmit` flagged it:

```
rsbuild.config.ts(14,5): error TS2769: No overload matches this call.
  Type 'string' has no properties in common with type 'FilenameConfig'.
```

Move it to `pluginLynx({ output: { filename: { bundle: ... } } })`, which is where the Lynx build engine reads it. `pluginReactLynx` applies `pluginLynx` itself only when it is not already registered (`isPluginLynxRegistered`), so applying it explicitly keeps a single instance and lets the options through.

The emitted filename is unchanged (`index.lynx.bundle`); this only makes the configuration real rather than inert.

Also drop `build:bundle:react` from `examples/external-bundle/turbo.json` — `build:bundle` still depended on it and it was still declared as a task, but the script it refers to no longer exists.

### Verification

`pnpm meta-updater --test` · `pnpm dprint check` · `pnpm changeset status` · `turbo run build --affected` (6/6) · `turbo run test --affected` — all pass locally, and `examples/with-rsbuild/dist/` still emits `index.lynx.bundle`.