### PR TITLE
fix(tanstack-router): pass origin to createRouter

### DIFF
--- a/.changeset/tanstack-router-origin.md
+++ b/.changeset/tanstack-router-origin.md
@@ -1,0 +1,5 @@
+---
+"@lynx-example/tanstack-router": patch
+---
+
+Pass `origin` to `createRouter` so `@tanstack/router-core` stops reading `window.origin` on the Lynx main thread.

--- a/examples/tanstack-router/src/App.tsx
+++ b/examples/tanstack-router/src/App.tsx
@@ -6,7 +6,12 @@ const memoryHistory = createMemoryHistory({
   initialEntries: ["/"],
 });
 
-const router = createRouter({ routeTree, history: memoryHistory, isServer: false });
+const router = createRouter({
+  routeTree,
+  history: memoryHistory,
+  isServer: false,
+  origin: "http://localhost",
+});
 
 export function App() {
   return <RouterProvider router={router} />;


### PR DESCRIPTION
Since `@tanstack/router-core` 1.139, `RouterCore.update()` reads `window?.origin` whenever `isServer` is false and no `origin` is given. The Lynx main thread has no `window` binding at all, so the optional chain still throws `ReferenceError: window is not defined` (LynxError 1101/110100) on every load. Passing `origin` skips that branch.

Verified on an Android Lynx Explorer: 1.166.2 without `origin` throws, with `origin` it is clean. Upgrading to 1.170.33 is not an alternative: it adds an unguarded `self` reference on the same path.
